### PR TITLE
Lot's of small improvements

### DIFF
--- a/perf-test/clj/reitit/perf_test.clj
+++ b/perf-test/clj/reitit/perf_test.clj
@@ -96,8 +96,9 @@
       (call)))
 
   ;; 1.0µs (-94%)
+  ;; 770ns (-95%, -23%)
   (title "reitit")
-  (let [call #(reitit/match-route reitit-routes "/workspace/1/1")]
+  (let [call #(reitit/match reitit-routes "/workspace/1/1")]
     (assert (call))
     (cc/quick-bench
       (call))))


### PR DESCRIPTION
* implement by-name (fixes #5)
* match-route => match
* implement routes
* by-name & match return Match-records (more info, faster to use)
* reitit.regex => reitit.impl