### PR TITLE
Match is injected into request

### DIFF
--- a/src/reitit/middleware.cljc
+++ b/src/reitit/middleware.cljc
@@ -1,5 +1,6 @@
 (ns reitit.middleware
-  (:require [reitit.core :as reitit]))
+  (:require [meta-merge.core :refer [meta-merge]]
+            [reitit.core :as reitit]))
 
 (defprotocol ExpandMiddleware
   (expand-middleware [this]))
@@ -40,5 +41,9 @@
    (ensure-handler! path meta scope)
    ((compose-middleware middleware) handler)))
 
-(defn router [data]
-  (reitit/router data {:compile compile-handler}))
+(defn router
+  ([data]
+   (router data nil))
+  ([data opts]
+   (let [opts (meta-merge {:compile compile-handler} opts)]
+     (reitit/router data opts))))

--- a/test/cljc/reitit/ring_test.cljc
+++ b/test/cljc/reitit/ring_test.cljc
@@ -130,6 +130,7 @@
       (if (and (seq required) (not (set/intersection required roles)))
         {:status 403, :body "forbidden"}
         (handler request)))))
+
 (deftest enforcing-meta-data-rules-at-runtime-test
   (let [handler (constantly {:status 200, :body "ok"})
         app (ring/ring-handler


### PR DESCRIPTION
Inject `Match` into request with `reitit.ring/router`. Also allow custom options to be passed to both `reitit.middleware/router` and `reitit.ring/router`. This enables for example easy way to mount shared :middleware for all routes. 

Together these enable that route meta-data can be interpreted also at runtime.

## Example

Middleware to enforce roles based on route meta-data (after route is matched):

```clj
(require '[reitit.ring :as ring])

(defn wrap-enforce-roles [handler]
  (fn [{:keys [::roles] :as request}]
    (let [required (some-> request (ring/get-match) :meta ::roles)]
      (if (and (seq required) (not (set/intersection required roles)))
        {:status 403, :body "forbidden"}
        (handler request)))))
```

Can be mounted for all routes:

```clj
(def handler (constantly {:status 200, :body "ok"}))

(def app
  (ring/ring-handler
    (ring/router
      [["/api"
        ["/ping" handler]
        ["/admin" {::roles #{:admin}}
         ["/ping" handler]]]]
      {:meta {:middleware [wrap-enforce-roles]}})))
```

Public route:

```clj
(app {:request-method :get, :uri "/api/ping"})
; {:status 200, :body "ok"}
```

Guarded route, without the roles:

```clj
(app {:request-method :get, :uri "/api/admin/ping"})
; {:status 403, :body "forbidden"}
```
Guarded route, with the needed roles:
```clj
(app {:request-method :get, :uri "/api/admin/ping", ::roles #{:admin}})
; {:status 200, :body "ok"}
``` 