### PR TITLE
Handle conflicting routes, custom & mixed-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ Routers can be configured via options. Options allow things like [`clojure.spec`
   | `:expand`    | Function of `arg opts => meta` to expand route arg to route meta-data (default `reitit.core/expand`)
   | `:coerce`    | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
   | `:compile`   | Function of `route opts => handler` to compile a route handler
-  | `:conflicts` | Function of `{route #{route}} => side-effect` to handle conflicting routes (default `reitit.core/throw-on-conflicts!`)"
+  | `:conflicts` | Function of `{route #{route}} => side-effect` to handle conflicting routes (default `reitit.core/throw-on-conflicts!`)
+  | `:router`    | Function of `routes opts => router` to override the actual router implementation
 
 ## Special thanks
 

--- a/README.md
+++ b/README.md
@@ -392,14 +392,15 @@ Authorized access to guarded route:
 
 Routers can be configured via options. Options allow things like [`clojure.spec`](https://clojure.org/about/spec) validation for meta-data and fast, compiled handlers. The following options are available for the `reitit.core/router`:
 
-  | key        | description |
-  | -----------|-------------|
-  | `:path`    | Base-path for routes (default `""`)
-  | `:routes`  | Initial resolved routes (default `[]`)
-  | `:meta`    | Initial expanded route-meta vector (default `[]`)
-  | `:expand`  | Function of `arg opts => meta` to expand route arg to route meta-data (default `reitit.core/expand`)
-  | `:coerce`  | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
-  | `:compile` | Function of `route opts => handler` to compile a route handler
+  | key          | description |
+  | -------------|-------------|
+  | `:path`      | Base-path for routes (default `""`)
+  | `:routes`    | Initial resolved routes (default `[]`)
+  | `:meta`      | Initial expanded route-meta vector (default `[]`)
+  | `:expand`    | Function of `arg opts => meta` to expand route arg to route meta-data (default `reitit.core/expand`)
+  | `:coerce`    | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
+  | `:compile`   | Function of `route opts => handler` to compile a route handler
+  | `:conflicts` | Function of `[route route] => side-effect` to handle conflicting routes (default `reitit.core/throw-on-conflicts!`)"
 
 ## Special thanks
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Routers can be configured via options. Options allow things like [`clojure.spec`
   | `:expand`    | Function of `arg opts => meta` to expand route arg to route meta-data (default `reitit.core/expand`)
   | `:coerce`    | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
   | `:compile`   | Function of `route opts => handler` to compile a route handler
-  | `:conflicts` | Function of `[route route] => side-effect` to handle conflicting routes (default `reitit.core/throw-on-conflicts!`)"
+  | `:conflicts` | Function of `{route #{route}} => side-effect` to handle conflicting routes (default `reitit.core/throw-on-conflicts!`)"
 
 ## Special thanks
 

--- a/perf-test/clj/reitit/opensensors_routing_test.clj
+++ b/perf-test/clj/reitit/opensensors_routing_test.clj
@@ -202,10 +202,10 @@
                "whoami" :test/route41
                "login" :test/route51}
         "v2/" {"whoami" :test/route1
-               ["users/" :user-id "/"] {"datasets" :test/route2
-                                        "devices" :test/route25
-                                        "topics" {"/bulk" :test/route29
-                                                  "" :test/route45}}
+               ["users/" :user-id] {"/datasets" :test/route2
+                                    "/devices" :test/route25
+                                    "/topics" {"/bulk" :test/route29
+                                               "" :test/route45}}
                "public/" {["projects/" :project-id] {"/datasets" :test/route3
                                                      "" :test/route27}
                           #_#_"messages/dataset/bulk" :test/route20
@@ -264,7 +264,7 @@
       "/v2/" {"whoami" [:test/route1]
               ["users/" user-id] {"/datasets" [:test/route2 user-id]
                                   "/devices" [:test/route25 user-id]
-                                  "topics/" {"bulk" [:test/route29 user-id]
+                                  "/topics" {"/bulk" [:test/route29 user-id]
                                              "" [:test/route45 user-id]}}
               "public/" {["projects/" project-id] {"/datasets" [:test/route3 project-id]
                                                    "" [:test/route27 project-id]}

--- a/perf-test/clj/reitit/opensensors_routing_test.clj
+++ b/perf-test/clj/reitit/opensensors_routing_test.clj
@@ -120,7 +120,7 @@
    ["/v1/orgs/:org-id/errors" {:handler handler, :name :test/route17}]
    ["/v1/public/orgs/:org-id" {:handler handler, :name :test/route18}]
    ["/v1/orgs/:org-id/invitations" {:handler handler, :name :test/route19}]
-   ["/v2/public/messages/dataset/bulk" {:handler handler, :name :test/route20}]
+   #_["/v2/public/messages/dataset/bulk" {:handler handler, :name :test/route20}]
    #_["/v1/users/:user-id/devices/bulk" {:handler handler, :name :test/route21}]
    ["/v1/users/:user-id/device-errors" {:handler handler, :name :test/route22}]
    ["/v2/login" {:handler handler, :name :test/route23}]
@@ -208,7 +208,7 @@
                                                   "" :test/route45}}
                "public/" {["projects/" :project-id] {"/datasets" :test/route3
                                                      "" :test/route27}
-                          "messages/dataset/bulk" :test/route20
+                          #_#_"messages/dataset/bulk" :test/route20
                           ["datasets/" :dataset-id] :test/route28
                           ["messages/dataset/" :dataset-id] :test/route53}
                ["datasets/" :dataset-id] :test/route11
@@ -268,7 +268,7 @@
                                              "" [:test/route45 user-id]}}
               "public/" {["projects/" project-id] {"/datasets" [:test/route3 project-id]
                                                    "" [:test/route27 project-id]}
-                         "messages/dataset/bulk" [:test/route20]
+                         #_#_"messages/dataset/bulk" [:test/route20]
                          ["datasets/" dataset-id] [:test/route28 dataset-id]
                          ["messages/dataset/" dataset-id] [:test/route53 dataset-id]}
               ["datasets/" dataset-id] [:test/route11 dataset-id]
@@ -344,7 +344,7 @@
         (context "/projects/:project-id" []
           (ANY "/datasets" [] {:name :test/route3} handler)
           (ANY "/" [] {:name :test/route27} handler))
-        (ANY "/messages/dataset/bulk" [] {:name :test/route20} handler)
+        #_(ANY "/messages/dataset/bulk" [] {:name :test/route20} handler)
         (ANY "/datasets/:dataset-id" [] {:name :test/route28} handler)
         (ANY "/messages/dataset/:dataset-id" [] {:name :test/route53} handler))
       (ANY "/datasets/:dataset-id" [] {:name :test/route11} handler)
@@ -376,7 +376,7 @@
        ["/v1/orgs/:org-id/errors" :get handler :route-name :test/route17]
        ["/v1/public/orgs/:org-id" :get handler :route-name :test/route18]
        ["/v1/orgs/:org-id/invitations" :get handler :route-name :test/route19]
-       ["/v2/public/messages/dataset/bulk" :get handler :route-name :test/route20]
+       #_["/v2/public/messages/dataset/bulk" :get handler :route-name :test/route20]
        #_["/v1/users/:user-id/devices/bulk" :get handler :route-name :test/route21]
        ["/v1/users/:user-id/device-errors" :get handler :route-name :test/route22]
        ["/v2/login" :get handler :route-name :test/route23]
@@ -493,12 +493,12 @@
         compojure-api-f #(opensensors-compojure-api-routes {:uri % :request-method :get})
         pedestal-f #(pedestal/find-route opensensors-pedestal-routes {:path-info % :request-method :get})]
 
-    (bench! routes true "reitit" reitit-f)                  ;;  2538ns    10%
-    (bench! routes true "pedestal" pedestal-f)              ;;  2737ns    11%
-    (bench! routes true "reitit-ring" reitit-ring-f)        ;;  2845ns    11%
-    (bench! routes true "compojure-api" compojure-api-f)    ;; 10215ns    41%
-    (bench! routes true "bidi" bidi-f)                      ;; 19298ns    77%
-    (bench! routes true "ataraxy" ataraxy-f)                ;; 24950ns   100%
+    (bench! routes true "reitit" reitit-f)                  ;;  2538ns -> 2028ns
+    (bench! routes true "reitit-ring" reitit-ring-f)        ;;  2845ns -> 2299ns
+    (bench! routes true "pedestal" pedestal-f)              ;;  2737ns
+    (bench! routes true "compojure-api" compojure-api-f)    ;;  9823ns
+    (bench! routes true "bidi" bidi-f)                      ;; 16716ns
+    (bench! routes true "ataraxy" ataraxy-f)                ;; 24467ns
 
     ))
 

--- a/src/reitit/core.cljc
+++ b/src/reitit/core.cljc
@@ -60,6 +60,12 @@
   (cond->> (->> (walk data opts) (map-meta merge-meta))
            coerce (into [] (keep #(coerce % opts)))))
 
+(defn first-conflicting-routes [routes]
+  (loop [[r & rest] routes]
+    (if (seq rest)
+      (or (some #(if (impl/conflicting-routes? r %) [r %]) rest)
+          (recur rest)))))
+
 (defn name-lookup [[_ {:keys [name]}] opts]
   (if name #{name}))
 

--- a/src/reitit/core.cljc
+++ b/src/reitit/core.cljc
@@ -86,7 +86,7 @@
   (if name #{name}))
 
 (defn find-names [routes opts]
-  (into [] (keep #(-> % second :name) routes)))
+  (into [] (keep #(-> % second :name)) routes))
 
 (defn compile-route [[p m :as route] {:keys [compile] :as opts}]
   [p m (if compile (compile route opts))])

--- a/src/reitit/core.cljc
+++ b/src/reitit/core.cljc
@@ -61,6 +61,7 @@
   (cond->> (->> (walk data opts) (map-meta merge-meta))
            coerce (into [] (keep #(coerce % opts)))))
 
+;; This whole function might be more efficient and easier to understand with transducers.
 (defn conflicting-routes [routes]
   (some->>
     (loop [[r & rest] routes, acc {}]

--- a/src/reitit/core.cljc
+++ b/src/reitit/core.cljc
@@ -81,7 +81,7 @@
 (defn compile-route [[p m :as route] {:keys [compile] :as opts}]
   [p m (if compile (compile route opts))])
 
-(defprotocol Routing
+(defprotocol Router
   (router-type [this])
   (routes [this])
   (options [this])
@@ -131,7 +131,7 @@
                          [[] {}] compiled)
          lookup (impl/fast-map lookup)]
      (reify
-       Routing
+       Router
        (router-type [_]
          :linear-router)
        (routes [_]
@@ -175,7 +175,7 @@
                               lookup)]) [{} {}] compiled)
          data (impl/fast-map data)
          lookup (impl/fast-map lookup)]
-     (reify Routing
+     (reify Router
        (router-type [_]
          :lookup-router)
        (routes [_]

--- a/src/reitit/core.cljc
+++ b/src/reitit/core.cljc
@@ -256,9 +256,11 @@
          routes (resolve-routes data opts)
          conflicting (conflicting-routes routes)
          wilds? (some impl/wild-route? routes)
+         all-wilds? (every? impl/wild-route? routes)
          router (cond
                   router router
                   (not wilds?) lookup-router
+                  all-wilds? linear-router
                   (not conflicting) mixed-router
                   :else linear-router)]
 

--- a/src/reitit/impl.cljc
+++ b/src/reitit/impl.cljc
@@ -129,6 +129,9 @@
 (defn- catch-all? [segment]
   (= \* (first segment)))
 
+(defn wild-route? [[path]]
+  (contains-wilds? path))
+
 (defn conflicting-routes? [[p1 :as route1] [p2 :as route2]]
   (loop [[s1 & ss1] (segments p1)
          [s2 & ss2] (segments p2)]

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -7,9 +7,9 @@
 
 (deftest reitit-test
 
-  (testing "mixed router"
+  (testing "linear-router"
     (let [router (reitit/router ["/api" ["/ipa" ["/:size" ::beer]]])]
-      (is (= :mixed-router (reitit/router-type router)))
+      (is (= :linear-router (reitit/router-type router)))
       (is (= [["/api/ipa/:size" {:name ::beer}]]
              (reitit/routes router)))
       (is (= true (map? (reitit/options router))))
@@ -40,7 +40,7 @@
               #"^missing path-params for route /api/ipa/:size: \#\{:size\}$"
               (reitit/match-by-name! router ::beer))))))
 
-  (testing "lookup router"
+  (testing "lookup-router"
     (let [router (reitit/router ["/api" ["/ipa" ["/large" ::beer]]])]
       (is (= :lookup-router (reitit/router-type router)))
       (is (= [["/api/ipa/large" {:name ::beer}]]

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -1,5 +1,5 @@
 (ns reitit.core-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is are]]
             [reitit.core :as reitit #?@(:cljs [:refer [Match]])])
   #?(:clj
      (:import (reitit.core Match)
@@ -138,3 +138,37 @@
                 :path "/api/user/1/2"
                 :params {:id "1", :sub-id "2"}})
              (reitit/match-by-path router "/api/user/1/2"))))))
+
+(deftest first-conflicting-routes-test
+  (are [conflicting? data]
+    (let [routes (reitit/resolve-routes data {})]
+      (= (if conflicting? routes)
+         (reitit/first-conflicting-routes
+           (reitit/resolve-routes routes {}))))
+
+    true [["/a"]
+          ["/a"]]
+
+    true [["/a"]
+          ["/:b"]]
+
+    true [["/a"]
+          ["/*b"]]
+
+    true [["/a/1/2"]
+          ["/*b"]]
+
+    false [["/a"]
+           ["/a/"]]
+
+    false [["/a"]
+           ["/a/1"]]
+
+    false [["/a"]
+           ["/a/:b"]]
+
+    false [["/a"]
+           ["/a/*b"]]
+
+    true [["/v2/public/messages/dataset/bulk"]
+          ["/v2/public/messages/dataset/:dataset-id"]]))

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -1,8 +1,8 @@
 (ns reitit.core-test
   (:require [clojure.test :refer [deftest testing is are]]
-            [reitit.core :as reitit #?@(:cljs [:refer [Match Routing]])])
+            [reitit.core :as reitit #?@(:cljs [:refer [Match]])])
   #?(:clj
-     (:import (reitit.core Match Routing)
+     (:import (reitit.core Match)
               (clojure.lang ExceptionInfo))))
 
 (deftest reitit-test
@@ -181,9 +181,9 @@
             (reitit/router
               [["/a"] ["/a"]]))))
     (testing "can be configured to ignore"
-      (is (instance?
-            Routing
-            (reitit/router
-              [["/a"] ["/a"]]
-              {:conflicts (constantly nil)}))))))
+      (is (not
+            (nil?
+              (reitit/router
+                [["/a"] ["/a"]]
+                {:conflicts (constantly nil)})))))))
 

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -1,8 +1,8 @@
 (ns reitit.core-test
   (:require [clojure.test :refer [deftest testing is are]]
-            [reitit.core :as reitit #?@(:cljs [:refer [Match]])])
+            [reitit.core :as reitit #?@(:cljs [:refer [Match Routing]])])
   #?(:clj
-     (:import (reitit.core Match)
+     (:import (reitit.core Match Routing)
               (clojure.lang ExceptionInfo))))
 
 (deftest reitit-test
@@ -171,4 +171,19 @@
            ["/a/*b"]]
 
     true [["/v2/public/messages/dataset/bulk"]
-          ["/v2/public/messages/dataset/:dataset-id"]]))
+          ["/v2/public/messages/dataset/:dataset-id"]])
+
+  (testing "router with conflicting routes"
+    (testing "throws by default"
+      (is (thrown-with-msg?
+            ExceptionInfo
+            #"router contains conflicting routes"
+            (reitit/router
+              [["/a"] ["/a"]]))))
+    (testing "can be configured to ignore"
+      (is (instance?
+            Routing
+            (reitit/router
+              [["/a"] ["/a"]]
+              {:conflicts (constantly nil)}))))))
+


### PR DESCRIPTION
* Handle conflicting routes by `router`. by default, throws an exception, can be overridden with `:conflicts` option. Fixes #23
* new `:mixed-router` delegating to `:linear-router` or `lookup-router`, -20% faster on rest-sample
* ability to define custom routers via `router` options

Example exception message on conflicting routes:

```clj
CompilerException clojure.lang.ExceptionInfo: router contains conflicting routes:

   /v2/public/messages/dataset/bulk
-> /v2/public/messages/dataset/:dataset-id

   /v1/users/:user-id/devices/bulk
-> /v1/users/:user-id/devices/:client-id
```