### PR TITLE
Small changes

### DIFF
--- a/doc/ring/data_driven_middleware.md
+++ b/doc/ring/data_driven_middleware.md
@@ -1,38 +1,98 @@
 # Data-driven Middleware
 
-Reitit supports first-class data-driven middleware via `reitit.ring.middleware/Middleware` records, created with `reitit.ring.middleware/create` function. The following keys have special purpose:
+Ring [defines middleware](https://github.com/ring-clojure/ring/wiki/Concepts#middleware) as a function of type `handler & opts => request => response`. It's easy to undrstand and enables great performance, but makes the middleware-chain opaque, making things like documentation and debugging hard.
 
-| key        | description |
-| -----------|-------------|
-| `:name`    | Name of the middleware as qualified keyword (optional,recommended for libs)
-| `:wrap`    | The actual middleware function of `handler args? => request => response`
-| `:gen`     | Middleware compile function, see [compiling middleware](compiling_middleware.md).
+Reitit does things bit differently:
 
-When routes are compiled, all middleware are expanded (and optionally compiled) into `Middleware` Records and stored in compilation results for later use (api-docs etc). For actual request processing, they are unwrapped into normal middleware functions and composed together producing zero runtime performance penalty. Middleware expansion is backed by `reitit.middleware/IntoMiddleware` protocol, enabling plain clojure(script) maps to be used.
+1. middleware is defined as a vector (of middleware) enabling the chain to be malipulated before turned into the optimized runtime chain.
+2. middleware can be defined as first-class data entries
 
-A Record:
+### Middleware as data
+
+Everything that is defined inside the `:middleware` vector in the route data is coerced into `reitit.ring.middleware/Middleware` Records with the help of `reitit.ring.middleware/IntoMiddleware` Protocol. By default, it transforms functions, maps and `Middleware` records. For the actual
+
+Records can have arbitrary keys, but the default keys have a special purpose:
+
+| key         | description |
+| ------------|-------------|
+| `:name`     | Name of the middleware as a qualified keyword (optional)
+| `:wrap`     | The actual middleware function of `handler & args => request => response`
+| `:gen-wrap` | Middleware function generation function, see [compiling middleware](compiling_middleware.md).
+
+Middleware Records are accessible in their raw form in the compiled route results, thus available for inventories, creating api-docs etc.
+
+For the actual request processing, the Records are unwrapped into normal functions, yielding zero runtime penalty.
+
+### Creating Middleware
+
+The following produce identical middleware runtime function.
+
+#### Function
 
 ```clj
-(require '[reitit.middleware :as middleware])
+(defn wrap [handler id]
+  (fn [request]
+    (handler (update request ::acc (fnil conj []) id))))
+```
+
+### Record
+
+```clj
+(require '[reitit.ring.middleware :as middleware])
 
 (def wrap2
   (middleware/create
     {:name ::wrap2
-     :description "a nice little mw, takes 1 arg."
+     :description "Middleware that does things."
      :wrap wrap}))
 ```
 
-As plain map:
+#### Map
 
 ```clj
-;; plain map
 (def wrap3
   {:name ::wrap3
-   :description "a nice little mw, :api as arg"
-   :wrap (fn [handler]
-           (wrap handler :api))})
+   :description "Middleware that does things."
+   :wrap wrap})
 ```
 
-### TODO
+### Using Middleware
 
-more!
+```clj
+(require '[reitit.ring :as ring])
+
+(defn handler [{:keys [::acc]}]
+  {:status 200, :body (conj acc :handler)})
+
+(def app
+  (ring/ring-handler
+    (ring/router
+      ["/api" {:middleware [[wrap 1] [wrap2 2]]}
+       ["/ping" {:get {:middleware [[wrap3 3]]
+                       :handler handler}}]])))
+```
+
+All the middleware are called correctly:
+
+```clj
+(app {:request-method :get, :uri "/api/ping"})
+; {:status 200, :body [1 2 3 :handler]}
+```
+
+### Future
+
+Some things bubblin' under:
+
+* Hooks to manipulate the `:middleware` chain before compilation
+* Support `Keyword` expansion into Middleware, enabling external Middleware Registries (duct/integrant/macchiato -style)
+* Support Middleware dependency resolution with new keys `:requires` and `:provides`. Values are set of top-level keys of the request. e.g.
+   * `InjectUserIntoRequestMiddleware` requires `#{:session}` and provides `#{:user}`
+   * `AuthorizationMiddleware` requires `#{:user}`
+* Support partial `s/keys` route data specs with Middleware (and Router). Merged together to define sound spec for the route data and/or route data for a given route.
+   * e.g. `AuthrorizationMiddleware` has a spec defining `:roles` key (a set of keywords)
+   * Documentation for the route data
+   * Route data is validated against the spec:
+      * Complain of keywords that are not handled by anything
+      * Propose fixes for typos (Figwheel-style)
+
+Ideas welcome & see [issues](https://github.com/metosin/reitit/issues) for details.

--- a/modules/reitit-ring/src/reitit/ring/coercion.cljc
+++ b/modules/reitit-ring/src/reitit/ring/coercion.cljc
@@ -136,17 +136,17 @@
   and :parameters from route meta, otherwise does not mount."
   (middleware/create
     {:name ::coerce-parameters
-     :gen (fn [{:keys [parameters coercion]} _]
-            (if (and coercion parameters)
-              (let [coercers (request-coercers coercion parameters)]
-                (fn [handler]
-                  (fn
-                    ([request]
-                     (let [coerced (coerce-parameters coercers request)]
-                       (handler (impl/fast-assoc request :parameters coerced))))
-                    ([request respond raise]
-                     (let [coerced (coerce-parameters coercers request)]
-                       (handler (impl/fast-assoc request :parameters coerced) respond raise))))))))}))
+     :gen-wrap (fn [{:keys [parameters coercion]} _]
+                 (if (and coercion parameters)
+                   (let [coercers (request-coercers coercion parameters)]
+                     (fn [handler]
+                       (fn
+                         ([request]
+                          (let [coerced (coerce-parameters coercers request)]
+                            (handler (impl/fast-assoc request :parameters coerced))))
+                         ([request respond raise]
+                          (let [coerced (coerce-parameters coercers request)]
+                            (handler (impl/fast-assoc request :parameters coerced) respond raise))))))))}))
 
 (defn wrap-coerce-response
   "Pluggable response coercion middleware.
@@ -182,12 +182,12 @@
   and :responses from route meta, otherwise does not mount."
   (middleware/create
     {:name ::coerce-response
-     :gen (fn [{:keys [responses coercion opts]} _]
-            (if (and coercion responses)
-              (let [coercers (response-coercers coercion responses opts)]
-                (fn [handler]
-                  (fn
-                    ([request]
-                     (coerce-response coercers request (handler request)))
-                    ([request respond raise]
-                     (handler request #(respond (coerce-response coercers request %)) raise)))))))}))
+     :gen-wrap (fn [{:keys [responses coercion opts]} _]
+                 (if (and coercion responses)
+                   (let [coercers (response-coercers coercion responses opts)]
+                     (fn [handler]
+                       (fn
+                         ([request]
+                          (coerce-response coercers request (handler request)))
+                         ([request respond raise]
+                          (handler request #(respond (coerce-response coercers request %)) raise)))))))}))

--- a/modules/reitit-ring/src/reitit/ring/middleware.cljc
+++ b/modules/reitit-ring/src/reitit/ring/middleware.cljc
@@ -8,11 +8,11 @@
 (defrecord Middleware [name wrap])
 (defrecord Endpoint [meta handler middleware])
 
-(defn create [{:keys [name gen wrap] :as m}]
-  (when (and gen wrap)
+(defn create [{:keys [name wrap gen-wrap] :as m}]
+  (when (and wrap gen-wrap)
     (throw
       (ex-info
-        (str "Middleware can't both :wrap and :gen defined " m) m)))
+        (str "Middleware can't both :wrap and :gen-wrap defined " m) m)))
   (map->Middleware m))
 
 (extend-protocol IntoMiddleware
@@ -40,13 +40,13 @@
     (into-middleware (create this) meta opts))
 
   Middleware
-  (into-middleware [{:keys [wrap gen] :as this} meta opts]
-    (if-not gen
+  (into-middleware [{:keys [wrap gen-wrap] :as this} meta opts]
+    (if-not gen-wrap
       this
-      (if-let [wrap (gen meta opts)]
+      (if-let [wrap (gen-wrap meta opts)]
         (map->Middleware
           (-> this
-              (dissoc :gen)
+              (dissoc :gen-wrap)
               (assoc :wrap wrap))))))
 
   nil

--- a/perf-test/clj/reitit/perf_test.clj
+++ b/perf-test/clj/reitit/perf_test.clj
@@ -71,45 +71,43 @@
 
   (suite "static route")
 
-  ;; 1800 µs
+  ;; 1600 µs
   (title "bidi")
-  (let [call #(bidi/match-route bidi-routes "/auth/login")]
-    (assert (call))
-    (cc/quick-bench
-      (dotimes [_ 1000]
-        (call))))
+  (assert (bidi/match-route bidi-routes "/auth/login"))
+  (cc/quick-bench
+    (dotimes [_ 1000]
+      (bidi/match-route bidi-routes "/auth/login")))
 
   ;; 1400 µs
   (title "ataraxy")
-  (let [call #(ataraxy/matches ataraxy-routes {:uri "/auth/login"})]
-    (assert (call))
+  (let [request {:uri "/auth/login"}]
+    (assert (ataraxy/matches ataraxy-routes request))
     (cc/quick-bench
       (dotimes [_ 1000]
-        (call))))
+        (ataraxy/matches ataraxy-routes request))))
 
-  ;; 1200 µs
+  ;; 1000 µs
   (title "pedestal - map-tree => prefix-tree")
-  (let [call #(pedestal/find-route pedestal-router {:path-info "/auth/login" :request-method :get})]
-    (assert (call))
+  (let [request {:path-info "/auth/login" :request-method :get}]
+    (assert (pedestal/find-route pedestal-router {:path-info "/auth/login" :request-method :get}))
     (cc/quick-bench
       (dotimes [_ 1000]
-        (call))))
+        (pedestal/find-route pedestal-router {:path-info "/auth/login" :request-method :get}))))
 
-  ;; 1400 µs
+  ;; 1500 µs
   (title "compojure-api")
-  (let [call #(compojure-api-routes {:uri "/auth/login", :request-method :get})]
-    (assert (call))
+  (let [request {:uri "/auth/login", :request-method :get}]
+    (assert (compojure-api-routes request))
     (cc/quick-bench
       (dotimes [_ 1000]
-        (call))))
+        (compojure-api-routes request))))
 
-  ;; 3.5 µs (300-500x)
+  ;; 3.2 µs (300-500x)
   (title "reitit")
-  (let [call #(reitit/match-by-path reitit-routes "/auth/login")]
-    (assert (call))
-    (cc/quick-bench
-      (dotimes [_ 1000]
-        (call)))))
+  (assert (reitit/match-by-path reitit-routes "/auth/login"))
+  (cc/quick-bench
+    (dotimes [_ 1000]
+      (reitit/match-by-path reitit-routes "/auth/login"))))
 
 (defn routing-test2 []
 
@@ -117,44 +115,42 @@
 
   ;; 12800 µs
   (title "bidi")
-  (let [call #(bidi/match-route bidi-routes "/workspace/1/1")]
-    (assert (call))
-    (cc/quick-bench
-      (dotimes [_ 1000]
-        (call))))
+  (assert (bidi/match-route bidi-routes "/workspace/1/1"))
+  (cc/quick-bench
+    (dotimes [_ 1000]
+      (bidi/match-route bidi-routes "/workspace/1/1")))
 
   ;; 2800 µs
   (title "ataraxy")
-  (let [call #(ataraxy/matches ataraxy-routes {:uri "/workspace/1/1"})]
-    (assert (call))
+  (let [request {:uri "/workspace/1/1"}]
+    (assert (ataraxy/matches ataraxy-routes request))
     (cc/quick-bench
       (dotimes [_ 1000]
-        (call))))
+        (ataraxy/matches ataraxy-routes request))))
 
-  ;; 2300 µs
-  (title "pedestal - map-tree => prefix-tree")
-  (let [call #(pedestal/find-route pedestal-router {:path-info "/workspace/1/1" :request-method :get})]
-    (assert (call))
+  ;; 2100 µs
+  (title "pedestal")
+  (let [request {:path-info "/workspace/1/1" :request-method :get}]
+    (assert (pedestal/find-route pedestal-router request))
     (cc/quick-bench
       (dotimes [_ 1000]
-        (call))))
+        (pedestal/find-route pedestal-router request))))
 
-  ;; 3800 µs
+  ;; 3500 µs
   (title "compojure-api")
-  (let [call #(compojure-api-routes {:uri "/workspace/1/1", :request-method :get})]
-    (assert (call))
+  (let [request {:uri "/workspace/1/1", :request-method :get}]
+    (assert (compojure-api-routes request))
     (cc/quick-bench
       (dotimes [_ 1000]
-        (call))))
+        (compojure-api-routes request))))
 
   ;; 710 µs (3-18x)
-  ;; 540 µs (4-23x) -23% prefix-tree-router
+  ;; 530 µs (4-24x) -25% prefix-tree-router
   (title "reitit")
-  (let [call #(reitit/match-by-path reitit-routes "/workspace/1/1")]
-    (assert (call))
-    (cc/quick-bench
-      (dotimes [_ 1000]
-        (call)))))
+  (assert (reitit/match-by-path reitit-routes "/workspace/1/1"))
+  (cc/quick-bench
+    (dotimes [_ 1000]
+      (reitit/match-by-path reitit-routes "/workspace/1/1"))))
 
 (defn reverse-routing-test []
 


### PR DESCRIPTION
Flushing changes from codemesh return trip stuff:
* `:gen` => `:gen-wrap` as preparation for support of interceptors
* rerun perf tests with latest all
* update docs