### PR TITLE
Support not-found with ring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: clojure
 lein: 2.7.1
 install:
@@ -20,3 +20,5 @@ cache:
   directories:
   - "$HOME/.m2"
   - "node_modules"
+addons:
+  chrome: stable

--- a/doc/ring/ring.md
+++ b/doc/ring/ring.md
@@ -112,22 +112,85 @@ Middleware is applied correctly:
 ; {:status 200, :body [:api :admin :db :delete :handler]}
 ```
 
-# Not found
+# Default handler
 
-If no routes match, `nil` is returned, which is not understood by Ring.
+By default, if no routes match, `nil` is returned, which is not valid response in Ring:
 
-Enabling custom error messages:
+```clj
+(defn handler [_]
+  {:status 200, :body ""})
+
+(def app
+  (ring/ring-handler
+    (ring/router
+      ["/ping" handler])))
+
+(app {:uri "/invalid"})
+; nil
+```
+
+Setting the default-handler as a second argument to `ring-handler`:
 
 ```clj
 (def app
-  (some-fn
-    (ring/ring-handler
-      (ring/router
-        ["/ping" handler]))
-    (constantly {:status 404})))
+  (ring/ring-handler
+    (ring/router
+      ["/ping" handler])
+    (constantly {:status 404, :body ""})))
 
 (app {:uri "/invalid"})
-; {:status 404}
+; {:status 404, :body ""}
+```
+
+To get more correct http error responses, `ring/create-default-handler` can be used. It differentiates `:not-found` (no route matched), `:method-not-accepted` (no method matched) and `:not-acceptable` (handler returned `nil`).
+
+With defaults:
+
+```clj
+(def app
+  (ring/ring-handler
+    (ring/router
+      [["/ping" {:get handler}]
+       ["/pong" (constantly nil)]])
+    (ring/create-default-handler)))
+
+(app {:request-method :get, :uri "/ping"})
+; {:status 200, :body ""}
+
+(app {:request-method :get, :uri "/"})
+; {:status 404, :body ""}
+
+(app {:request-method :post, :uri "/ping"})
+; {:status 405, :body ""}
+
+(app {:request-method :get, :uri "/pong"})
+; {:status 406, :body ""}
+```
+
+With custom responses:
+
+```clj
+(def app
+  (ring/ring-handler
+    (ring/router
+      [["/ping" {:get handler}]
+       ["/pong" (constantly nil)]])
+    (ring/create-default-handler
+      {:not-found (constantly {:status 404, :body "kosh"})
+       :method-not-allowed (constantly {:status 405, :body "kosh"})
+       :not-acceptable (constantly {:status 406, :body "kosh"})})))
+
+(app {:request-method :get, :uri "/ping"})
+; {:status 200, :body ""}
+
+(app {:request-method :get, :uri "/"})
+; {:status 404, :body "kosh"}
+
+(app {:request-method :post, :uri "/ping"})
+; {:status 405, :body "kosh"}
+
+(app {:request-method :get, :uri "/pong"})
+; {:status 406, :body "kosh"}
 ```
 
 # Async Ring

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -15,36 +15,76 @@
         [top (assoc childs k v)]
         [(assoc top k v) childs])) [{} {}] data))
 
+(defn create-default-handler
+  "A default ring handler that can handle the following cases,
+  configured via options:
+
+  | key                    | description |
+  | -----------------------|-------------|
+  | `:not-found`           | 404, no routes matches
+  | `:method-not-accepted` | 405, no method matches
+  | `:not-acceptable`      | 406, handler returned `nil`"
+  ([]
+   (create-default-handler
+     {:not-found (constantly {:status 404, :body ""})
+      :method-not-allowed (constantly {:status 405, :body ""})
+      :not-acceptable (constantly {:status 406, :body ""})}))
+  ([{:keys [not-found method-not-allowed not-acceptable]}]
+   (fn
+     ([request]
+      (if-let [match (::match request)]
+        (let [method (:request-method request :any)
+              result (:result match)
+              handler? (or (-> result method :handler) (-> result :any :handler))
+              error-handler (if handler? not-acceptable method-not-allowed)]
+          (error-handler request))
+        (not-found request)))
+     ([request respond _]
+      (if-let [match (::match request)]
+        (let [method (:request-method request :any)
+              result (:result match)
+              handler? (or (-> result method :handler) (-> result :any :handler))
+              error-handler (if handler? not-acceptable method-not-allowed)]
+          (respond (error-handler request)))
+        (respond (not-found request)))))))
+
 (defn ring-handler
   "Creates a ring-handler out of a ring-router.
-  Supports both 1 (sync) and 3 (async) arities."
+  Supports both 1 (sync) and 3 (async) arities.
+  Optionally takes a ring-handler which is called
+  in no route matches."
   ([router]
-    (ring-handler router (constantly nil)))
+   (ring-handler router nil))
   ([router default-handler]
-    (with-meta
-      (fn
-        ([request]
-         (if-let [match (r/match-by-path router (:uri request))]
-           (let [method (:request-method request :any)
-                 params (:params match)
-                 result (:result match)
-                 handler (or (-> result method :handler)
-                             (-> result :any (:handler default-handler)))
-                 request (cond-> (impl/fast-assoc request ::match match)
-                                 (seq params) (impl/fast-assoc :path-params params))]
-             (handler request))))
-        ([request respond raise]
-         (if-let [match (r/match-by-path router (:uri request))]
-           (let [method (:request-method request :any)
-                 params (:params match)
-                 result (:result match)
-                 handler (or (-> result method :handler)
-                             (-> result :any (:handler default-handler)))
-                 request (cond-> (impl/fast-assoc request ::match match)
-                                 (seq params) (impl/fast-assoc :path-params params))]
-             (handler request respond raise))
-           (respond nil))))
-      {::router router})))
+   (let [default-handler (or default-handler (fn ([_]) ([_ respond _] (respond nil))))]
+     (with-meta
+       (fn
+         ([request]
+          (if-let [match (r/match-by-path router (:uri request))]
+            (let [method (:request-method request :any)
+                  params (:params match)
+                  result (:result match)
+                  handler (or (-> result method :handler)
+                              (-> result :any (:handler default-handler)))
+                  request (cond-> (impl/fast-assoc request ::match match)
+                                  (seq params) (impl/fast-assoc :path-params params))
+                  response (handler request)]
+              (if (nil? response)
+                (default-handler request)
+                response))
+            (default-handler request)))
+         ([request respond raise]
+          (if-let [match (r/match-by-path router (:uri request))]
+            (let [method (:request-method request :any)
+                  params (:params match)
+                  result (:result match)
+                  handler (or (-> result method :handler)
+                              (-> result :any (:handler default-handler)))
+                  request (cond-> (impl/fast-assoc request ::match match)
+                                  (seq params) (impl/fast-assoc :path-params params))]
+              (handler request respond raise))
+            (default-handler request respond raise))))
+       {::router router}))))
 
 (defn get-router [handler]
   (some-> handler meta ::router))


### PR DESCRIPTION
Implemented the pluggable `default-handler` for ring, with a generator for  `:not-found`,  `:method-not-accepted` & `:not-acceptable`

Completes #61.