### PR TITLE
Handle queries and fragments in URL

### DIFF
--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -37,6 +37,13 @@
 (defn wild-or-catch-all-param? [x]
   (boolean (or (wild-param x) (catch-all-param x))))
 
+(defn pre-process-path [path]
+  (let [[path fragment] (str/split path #"#" 2)
+        [path query] (str/split path #"\?" 2)]
+    (cond-> {:path path}
+      fragment (assoc :fragment-string fragment)
+      query (assoc :query-string query))))
+
 (defn segments [path]
   #?(:clj  (.split ^String path "/" 666)
      :cljs (.split path #"/" 666)))

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -66,6 +66,7 @@
             (is (= ::jabba2 (matches "/abba/2")))
             (is (= ::doo (matches "/abba/1/doo")))
             (is (= ::boo (matches "/abba/1/boo")))
+            (is (= ::boo (matches "/abba/1/boo?foo=doo#zoo")))
             (is (= ::wild (matches "/olipa/kerran/avaruus/vaan/ei/toista/kertaa"))))))
 
       r/linear-router :linear-router
@@ -85,6 +86,14 @@
                   :path "/api/ipa/large"
                   :path-params {}})
                (r/match-by-path router "/api/ipa/large")))
+        (is (= (r/map->Match
+                {:template "/api/ipa/large"
+                 :data {:name ::beer}
+                 :path "/api/ipa/large?glass=pint#cold"
+                 :path-params {}
+                 :query-string "glass=pint"
+                 :fragment-string "cold"})
+               (r/match-by-path router "/api/ipa/large?glass=pint#cold")))
         (is (= (r/map->Match
                  {:template "/api/ipa/large"
                   :data {:name ::beer}


### PR DESCRIPTION
Fixing #77 
To solve handling of queries and fragments in a provided URL, I added a pre-process step that splits the URL in three parts and returns a map containing the trimmed path and the fragment and query strings if present. I am unsure how query params should fit into the larger API of parameter coercion, so I have left the query unparsed.

I understand that the duplication of merge logic with matches across each implementation of the Router protocol is less than ideal, but wanted to make as small a change to the existing API as possible. If you have an idea of how to better support URL trimming I am happy to help out with implementing it.