### PR TITLE
fix various links in documentation

### DIFF
--- a/doc/coercion/coercion.md
+++ b/doc/coercion/coercion.md
@@ -39,7 +39,7 @@ Reitit ships with the following coercion modules:
 * `reitit.coercion.schema/coercion` for [plumatic schema](https://github.com/plumatic/schema)
 * `reitit.coercion.spec/coercion` for both [clojure.spec](https://clojure.org/about/spec) and [data-specs](https://github.com/metosin/spec-tools#data-specs)
 
-Coercion can be attached to route data under `:coercion` key. There can be multiple `Coercion` implementations within a single router, normal [scoping rules](../basics/route_data.html#nested-route-data) apply.
+Coercion can be attached to route data under `:coercion` key. There can be multiple `Coercion` implementations within a single router, normal [scoping rules](../basics/route_data.md#nested-route-data) apply.
 
 ## Defining parameters
 

--- a/doc/ring/coercion.md
+++ b/doc/ring/coercion.md
@@ -18,7 +18,7 @@ Reitit ships with the following coercion modules:
 * `reitit.coercion.schema/coercion` for [plumatic schema](https://github.com/plumatic/schema)
 * `reitit.coercion.spec/coercion` for both [clojure.spec](https://clojure.org/about/spec) and [data-specs](https://github.com/metosin/spec-tools#data-specs)
 
-Coercion can be attached to route data under `:coercion` key. There can be multiple `Coercion` implementations within a single router, normal [scoping rules](../basics/route_data.html#nested-route-data) apply.
+Coercion can be attached to route data under `:coercion` key. There can be multiple `Coercion` implementations within a single router, normal [scoping rules](../basics/route_data.md#nested-route-data) apply.
 
 ## Defining parameters and responses
 
@@ -137,7 +137,7 @@ Invalid response:
 
 ### Optimizations
 
-The coercion middleware are [compiled againts a route](compiling_middleware,md). In the middleware compilation step the actual coercer implementations are constructed for the defined models. Also, the middleware doesn't mount itself if a route doesn't have `:coercion` and `:parameters` or `:responses` defined.
+The coercion middleware are [compiled againts a route](compiling_middleware.md). In the middleware compilation step the actual coercer implementations are constructed for the defined models. Also, the middleware doesn't mount itself if a route doesn't have `:coercion` and `:parameters` or `:responses` defined.
 
 We can query the compiled middleware chain for the routes:
 

--- a/doc/ring/swagger.md
+++ b/doc/ring/swagger.md
@@ -31,7 +31,7 @@ Coercion keys also contribute to the docs:
 | :parameters   | optional input parameters for a route, in a format defined by the coercion
 | :responses    | optional descriptions of responess, in a format defined by coercion
 
-There is a `reitit.swagger.swagger-feature`, which acts as both a `Middleware` and an `Interceptor` that is not participating in any request processing - it just defines the route data specs for the routes it's mounted to. It is only needed if the [route data validation](route_data_validation.html) is turned on.
+There is a `reitit.swagger.swagger-feature`, which acts as both a `Middleware` and an `Interceptor` that is not participating in any request processing - it just defines the route data specs for the routes it's mounted to. It is only needed if the [route data validation](route_data_validation.md) is turned on.
 
 ## Swagger spec
 
@@ -197,7 +197,7 @@ http://localhost:3000 should render now the swagger-ui:
 
 ## Advanced
 
-Route data in path `[:swagger :id]` can be either a keyword or a sequence of keywords. This enables one route to be part of multiple swagger apis. Normal route data [scoping rules](../basics/route_data.html#nested-route-data) rules apply.
+Route data in path `[:swagger :id]` can be either a keyword or a sequence of keywords. This enables one route to be part of multiple swagger apis. Normal route data [scoping rules](../basics/route_data.md#nested-route-data) rules apply.
 
 Example with:
 


### PR DESCRIPTION
These probably work in Gitbook to some extent but they don't work on
GitHub. In most places of the documentation files are referenced
via their source files (`.md`) and I assume Gitbook deals fine with that

For cljdoc the correct links are required to properly fix links that are
broken when rendering the document on different URLs.