### PR TITLE
0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
   (is (= [] (r/routes (r/router ["/ping" [nil "/pong"]])))))
 ```
+### `reitit-ring`
+
+* Use HTTP redirect (302) with index-files in `reitit.ring/create-resource-handler`.
 
 ### `reitit-schema`
 
@@ -28,6 +31,8 @@
 * Fix Swagger-paths, by [Kirill Chernyshov](https://github.com/DeLaGuardo).
 
 ### `reitit-swagger-ui`
+
+* Use HTTP redirect (302) with index-files in `reitit.swagger-ui/create-swagger-ui-handler`.
 
 * updated dependencies:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## 0.1.2-SNAPSHOT
 
+### `reitit-core`
+
+* Better handling of `nil` routes - they filtered away from route syntax before routes are expanded:
+
+```clj
+(testing "nil routes are allowed ans stripped"
+  (is (= [] (r/routes (r/router nil))))
+  (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
+  (is (= [["/ping" {} nil]] (r/routes (r/router [nil [nil] ["/ping"]]))))
+  (is (= [["/ping" {} nil]] (r/routes (r/router [[[nil [nil] ["/ping"]]]])))))
+```
+
 ### `reitit-schema`
 
 * updated dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 ### `reitit-core`
 
-* Better handling of `nil` routes - they filtered away from route syntax before routes are expanded:
+* Better handling of `nil` in route syntax:
+  * explicit `nil` after path string is always handled as `nil` route
+  * `nil` as path string causes the whole route to be `nil`
+  * `nil` as child route is stripped away
 
 ```clj
-(testing "nil routes are allowed ans stripped"
+(testing "nil routes are stripped"
   (is (= [] (r/routes (r/router nil))))
+  (is (= [] (r/routes (r/router [nil ["/ping"]]))))
   (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
-  (is (= [["/ping" {} nil]] (r/routes (r/router [nil [nil] ["/ping"]]))))
-  (is (= [["/ping" {} nil]] (r/routes (r/router [[[nil [nil] ["/ping"]]]])))))
+  (is (= [] (r/routes (r/router ["/ping" [nil "/pong"]])))))
 ```
 
 ### `reitit-schema`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 ### `reitit-ring`
 
 * Use HTTP redirect (302) with index-files in `reitit.ring/create-resource-handler`.
+* `reitit.ring/create-default-handler` now conforms to [RING Spec](https://github.com/ring-clojure/ring/blob/master/SPEC), Fixes [#83](https://github.com/metosin/reitit/issues/83)
+
+https://github.com/metosin/reitit/issues/83
 
 ### `reitit-schema`
 

--- a/doc/ring/swagger.md
+++ b/doc/ring/swagger.md
@@ -183,7 +183,7 @@ Whole example project is in [`/examples/ring-swagger`](https://github.com/metosi
                                     "application/transit+json"}}}})
     (ring/routes
       (swagger-ui/create-swagger-ui-handler
-        {:path "", :url "/api/swagger.json"})
+        {:path "/", :url "/api/swagger.json"})
       (ring/create-default-handler))))
 
 (defn start []

--- a/examples/just-coercion-with-ring/project.clj
+++ b/examples/just-coercion-with-ring/project.clj
@@ -3,4 +3,4 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [ring "1.6.3"]
                  [metosin/muuntaja "0.4.1"]
-                 [metosin/reitit "0.1.1"]])
+                 [metosin/reitit "0.1.2-SNAPSHOT"]])

--- a/examples/ring-example/project.clj
+++ b/examples/ring-example/project.clj
@@ -3,4 +3,4 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [ring "1.6.3"]
                  [metosin/muuntaja "0.4.1"]
-                 [metosin/reitit "0.1.1"]])
+                 [metosin/reitit "0.1.2-SNAPSHOT"]])

--- a/examples/ring-swagger/project.clj
+++ b/examples/ring-swagger/project.clj
@@ -3,5 +3,5 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [ring "1.6.3"]
                  [metosin/muuntaja "0.5.0"]
-                 [metosin/reitit "0.1.1"]]
+                 [metosin/reitit "0.1.2-SNAPSHOT"]]
   :repl-options {:init-ns example.server})

--- a/modules/reitit-core/project.clj
+++ b/modules/reitit-core/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit-core "0.1.1"
+(defproject metosin/reitit-core "0.1.2-SNAPSHOT"
   :description "Snappy data-driven router for Clojure(Script)"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"

--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -37,16 +37,17 @@
     [(walk-many [p m r]
        (reduce #(into %1 (walk-one p m %2)) [] r))
      (walk-one [pacc macc routes]
-       (if (vector? (first routes))
-         (walk-many pacc macc routes)
-         (let [[path & [maybe-arg :as args]] routes
-               [data childs] (if (vector? maybe-arg)
-                               [{} args]
-                               [maybe-arg (rest args)])
-               macc (into macc (expand data opts))]
-           (if (seq childs)
-             (walk-many (str pacc path) macc childs)
-             [[(str pacc path) macc]]))))]
+       (if-let [routes (seq (keep identity routes))]
+         (if (vector? (first routes))
+           (walk-many pacc macc routes)
+           (let [[path & [maybe-arg :as args]] routes
+                 [data childs] (if (vector? maybe-arg)
+                                 [{} args]
+                                 [maybe-arg (rest args)])
+                 macc (into macc (expand data opts))]
+             (if (seq childs)
+               (walk-many (str pacc path) macc childs)
+               [[(str pacc path) macc]])))))]
     (walk-one path (mapv identity data) raw-routes)))
 
 (defn map-data [f routes]
@@ -87,10 +88,10 @@
       (conflicts-str conflicts)
       {:conflicts conflicts})))
 
-(defn name-lookup [[_ {:keys [name]}] opts]
+(defn name-lookup [[_ {:keys [name]}] _]
   (if name #{name}))
 
-(defn find-names [routes opts]
+(defn find-names [routes _]
   (into [] (keep #(-> % second :name)) routes))
 
 (defn- compile-route [[p m :as route] {:keys [compile] :as opts}]

--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -37,17 +37,16 @@
     [(walk-many [p m r]
        (reduce #(into %1 (walk-one p m %2)) [] r))
      (walk-one [pacc macc routes]
-       (if-let [routes (seq (keep identity routes))]
-         (if (vector? (first routes))
-           (walk-many pacc macc routes)
+       (if (vector? (first routes))
+         (walk-many pacc macc routes)
+         (if (string? (first routes))
            (let [[path & [maybe-arg :as args]] routes
-                 [data childs] (if (vector? maybe-arg)
+                 [data childs] (if (or (vector? maybe-arg) (nil? maybe-arg))
                                  [{} args]
                                  [maybe-arg (rest args)])
-                 macc (into macc (expand data opts))]
-             (if (seq childs)
-               (walk-many (str pacc path) macc childs)
-               [[(str pacc path) macc]])))))]
+                 macc (into macc (expand data opts))
+                 child-routes (walk-many (str pacc path) macc (keep identity childs))]
+             (if (seq childs) (seq child-routes) [[(str pacc path) macc]])))))]
     (walk-one path (mapv identity data) raw-routes)))
 
 (defn map-data [f routes]

--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -39,7 +39,7 @@
      (walk-one [pacc macc routes]
        (if (vector? (first routes))
          (walk-many pacc macc routes)
-         (if (string? (first routes))
+         (when (string? (first routes))
            (let [[path & [maybe-arg :as args]] routes
                  [data childs] (if (or (vector? maybe-arg) (nil? maybe-arg))
                                  [{} args]

--- a/modules/reitit-core/src/reitit/spec.cljc
+++ b/modules/reitit-core/src/reitit/spec.cljc
@@ -9,18 +9,19 @@
 
 (s/def ::path (s/with-gen string? #(gen/fmap (fn [s] (str "/" s)) (s/gen string?))))
 
-(s/def ::arg (s/and any? (complement vector?)))
+(s/def ::arg (s/and some? (complement vector?)))
 (s/def ::data (s/map-of keyword? any?))
 (s/def ::result any?)
 
 (s/def ::raw-route
-  (s/cat :path ::path
-         :arg (s/? ::arg)
-         :childs (s/* (s/and (s/nilable ::raw-route)))))
+  (s/nilable
+    (s/cat :path ::path
+           :arg (s/? ::arg)
+           :childs (s/* (s/and (s/nilable ::raw-routes))))))
 
 (s/def ::raw-routes
   (s/or :route ::raw-route
-        :routes (s/coll-of ::raw-route :into [])))
+        :routes (s/coll-of ::raw-routes :into [])))
 
 (s/def ::route
   (s/cat :path ::path

--- a/modules/reitit-ring/project.clj
+++ b/modules/reitit-ring/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit-ring "0.1.1"
+(defproject metosin/reitit-ring "0.1.2-SNAPSHOT"
   :description "Reitit: Ring routing"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -107,7 +107,7 @@
                                          (loop [[file & files] index-files]
                                            (if file
                                              (if (resource-response (join-paths path file))
-                                               {:status 302 :headers {"Location" (join-paths uri file)}}
+                                               (response/redirect (join-paths uri file))
                                                (recur files))))))
             handler (if path
                       (fn [request]

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -129,7 +129,7 @@
        (fn
          ([request]
           (if-let [match (r/match-by-path router (:uri request))]
-            (let [method (:request-method request :any)
+            (let [method (:request-method request)
                   path-params (:path-params match)
                   result (:result match)
                   handler (-> result method :handler (or default-handler))
@@ -141,7 +141,7 @@
             (default-handler request)))
          ([request respond raise]
           (if-let [match (r/match-by-path router (:uri request))]
-            (let [method (:request-method request :any)
+            (let [method (:request-method request)
                   path-params (:path-params match)
                   result (:result match)
                   handler (-> result method :handler (or default-handler))

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -46,9 +46,9 @@
   | `:not-acceptable`      | 406, handler returned `nil`"
   ([]
    (create-default-handler
-     {:not-found (constantly {:status 404, :body ""})
-      :method-not-allowed (constantly {:status 405, :body ""})
-      :not-acceptable (constantly {:status 406, :body ""})}))
+     {:not-found (constantly {:status 404, :body "", :headers {}})
+      :method-not-allowed (constantly {:status 405, :body "", :headers {}})
+      :not-acceptable (constantly {:status 406, :body "", :headers {}})}))
   ([{:keys [not-found method-not-allowed not-acceptable]}]
    (fn
      ([request]

--- a/modules/reitit-schema/project.clj
+++ b/modules/reitit-schema/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit-schema "0.1.1"
+(defproject metosin/reitit-schema "0.1.2-SNAPSHOT"
   :description "Reitit: Plumatic Schema coercion"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"

--- a/modules/reitit-spec/project.clj
+++ b/modules/reitit-spec/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit-spec "0.1.1"
+(defproject metosin/reitit-spec "0.1.2-SNAPSHOT"
   :description "Reitit: clojure.spec coercion"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"

--- a/modules/reitit-swagger-ui/project.clj
+++ b/modules/reitit-swagger-ui/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit-swagger-ui "0.1.1"
+(defproject metosin/reitit-swagger-ui "0.1.2-SNAPSHOT"
   :description "Reitit: Swagger-ui support"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"

--- a/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
+++ b/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
@@ -26,7 +26,7 @@
 
         ;; with path and url set, swagger validator disabled
         (swagger-ui/create-swagger-ui-handler
-          {:path \"\"
+          {:path \"/\"
            :url \"/api/swagger.json\"
            :config {:validator-url nil})"
      ([]

--- a/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
+++ b/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
@@ -42,11 +42,11 @@
                           (update $ :root (fnil identity "swagger-ui"))
                           (update $ :url (fnil identity "/swagger.json"))
                           (update $ :config #(->> % (map mixed-case-key) (into {})))
-                          (assoc $ :paths {"conf.js" {:headers {"Content-Type" "application/javascript"}
-                                                      :status 200
-                                                      :body (conf-js $)}
-                                           "config.json" {:headers {"Content-Type" "application/json"}
-                                                          :status 200
-                                                          :body (config-json $)}}))]
+                          (assoc $ :paths {"/conf.js" {:headers {"Content-Type" "application/javascript"}
+                                                       :status 200
+                                                       :body (conf-js $)}
+                                           "/config.json" {:headers {"Content-Type" "application/json"}
+                                                           :status 200
+                                                           :body (config-json $)}}))]
         (ring/routes
           (ring/create-resource-handler options))))))

--- a/modules/reitit-swagger/project.clj
+++ b/modules/reitit-swagger/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit-swagger "0.1.1"
+(defproject metosin/reitit-swagger "0.1.2-SNAPSHOT"
   :description "Reitit: Swagger-support"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"

--- a/modules/reitit/project.clj
+++ b/modules/reitit/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit "0.1.1"
+(defproject metosin/reitit "0.1.2-SNAPSHOT"
   :description "Snappy data-driven router for Clojure(Script)"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"

--- a/perf-test/clj/reitit/json_perf.cljc
+++ b/perf-test/clj/reitit/json_perf.cljc
@@ -1,0 +1,109 @@
+(ns reitit.json-perf
+  (:require [criterium.core :as cc]
+            [reitit.perf-utils :refer :all]
+
+    ;; reitit
+            [reitit.ring :as ring]
+            [muuntaja.middleware :as mm]
+
+    ;; bidi-yada
+            [yada.yada :as yada]
+            [bidi.ring :as bidi-ring]
+            [byte-streams :as bs]
+
+    ;; defaults
+            [ring.middleware.defaults :as defaults]
+            [compojure.core :as compojure]
+            [clojure.string :as str]))
+
+;;
+;; start repl with `lein perf repl`
+;; perf measured with the following setup:
+;;
+;; Model Name:            MacBook Pro
+;; Model Identifier:      MacBookPro113
+;; Processor Name:        Intel Core i7
+;; Processor Speed:       2,5 GHz
+;; Number of Processors:  1
+;; Total Number of Cores: 4
+;; L2 Cache (per Core):   256 KB
+;; L3 Cache:              6 MB
+;; Memory:                16 GB
+;;
+
+;; TODO: naive implementation
+(defn- with-security-headers [response]
+  (update
+    response
+    :headers
+    (fn [headers]
+      (-> headers
+          (assoc "x-frame-options" "SAMEORIGIN")
+          (assoc "x-xss-protection" "1; mode=block")
+          (assoc "x-content-type-options" "nosniff")))))
+
+(def security-middleware
+  {:name ::security
+   :wrap (fn [handler]
+           (fn [request]
+             (with-security-headers (handler request))))})
+
+(def reitit-app
+  (ring/ring-handler
+    (ring/router
+      ["/api/ping"
+       {:get {:handler (fn [_] {:status 200, :body {:ping "pong"}})}}]
+      {:data {:middleware [mm/wrap-format
+                           security-middleware]}})))
+
+(def bidi-yada-app
+  (bidi-ring/make-handler
+    ["/api/ping"
+     (yada/resource
+       {:produces {:media-type "application/json"}
+        :methods {:get {:response (fn [_] {:ping "pong"})}}})]))
+
+(def defaults-app
+  (defaults/wrap-defaults
+    (mm/wrap-format
+      (compojure/GET "/api/ping" [] {:status 200, :body {:ping "pong"}}))
+    defaults/site-defaults))
+
+(def request {:request-method :get, :uri "/api/ping"})
+
+(comment
+  (defaults-app request)
+  @(bidi-yada-app request)
+  (reitit-app request))
+
+(comment
+  (slurp (:body (defaults-app request)))
+  (slurp (:body (reitit-app request)))
+  (bs/to-string (:body @(bidi-yada-app request))))
+
+
+(defn expect! [body]
+  (assert (str/starts-with? body "{\"ping\":\"pong\"}")))
+
+(defn perf-test []
+
+  ;; 176µs
+  (title "compojure + ring-defaults")
+  (let [f (fn [] (defaults-app request))]
+    (expect! (-> (f) :body slurp))
+    (cc/quick-bench (f)))
+
+  ;; 60µs
+  (title "bidi + yada")
+  (let [f (fn [] (bidi-yada-app request))]
+    (expect! (-> (f) deref :body bs/to-string))
+    (cc/quick-bench (f)))
+
+  ;; 5.0µs
+  (title "reitit-ring")
+  (let [f (fn [] (reitit-app request))]
+    (expect! (-> (f) :body slurp))
+    (cc/quick-bench (f))))
+
+(comment
+  (perf-test))

--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,7 @@
 
                                   [ring "1.6.3"]
                                   [ikitommi/immutant-web "3.0.0-alpha1"]
-                                  [metosin/muuntaja "0.5.0"]
+                                  [metosin/muuntaja "0.6.0-SNAPSHOT"]
                                   [metosin/ring-swagger-ui "2.2.10"]
                                   [metosin/jsonista "0.2.1"]
 
@@ -70,6 +70,8 @@
                                    [ikitommi/immutant-web "3.0.0-alpha1"]
                                    [io.pedestal/pedestal.route "0.5.3"]
                                    [org.clojure/core.async "0.4.474"]
+                                   [yada "1.2.13"]
+                                   [ring/ring-defaults "0.3.1"]
                                    [ataraxy "0.4.0"]
                                    [bidi "2.1.3"]]}
              :analyze {:jvm-opts ^:replace ["-server"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/reitit-parent "0.1.1"
+(defproject metosin/reitit-parent "0.1.2-SNAPSHOT"
   :description "Snappy data-driven router for Clojure(Script)"
   :url "https://github.com/metosin/reitit"
   :license {:name "Eclipse Public License"
@@ -9,13 +9,13 @@
           :source-uri "https://github.com/metosin/reitit/{version}/{filepath}#L{line}"
           :metadata {:doc/format :markdown}}
 
-  :managed-dependencies [[metosin/reitit "0.1.1"]
-                         [metosin/reitit-core "0.1.1"]
-                         [metosin/reitit-ring "0.1.1"]
-                         [metosin/reitit-spec "0.1.1"]
-                         [metosin/reitit-schema "0.1.1"]
-                         [metosin/reitit-swagger "0.1.1"]
-                         [metosin/reitit-swagger-ui "0.1.1"]
+  :managed-dependencies [[metosin/reitit "0.1.2-SNAPSHOT"]
+                         [metosin/reitit-core "0.1.2-SNAPSHOT"]
+                         [metosin/reitit-ring "0.1.2-SNAPSHOT"]
+                         [metosin/reitit-spec "0.1.2-SNAPSHOT"]
+                         [metosin/reitit-schema "0.1.2-SNAPSHOT"]
+                         [metosin/reitit-swagger "0.1.2-SNAPSHOT"]
+                         [metosin/reitit-swagger-ui "0.1.2-SNAPSHOT"]
 
                          [meta-merge "1.0.0"]
                          [ring/ring-core "1.6.3"]

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -108,11 +108,11 @@
       r/segment-router :segment-router
       r/mixed-router :mixed-router))
 
-  (testing "nil routes are allowed ans stripped"
+  (testing "nil routes are stripped"
     (is (= [] (r/routes (r/router nil))))
+    (is (= [] (r/routes (r/router [nil ["/ping"]]))))
     (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
-    (is (= [["/ping" {} nil]] (r/routes (r/router [nil [nil] ["/ping"]]))))
-    (is (= [["/ping" {} nil]] (r/routes (r/router [[[nil [nil] ["/ping"]]]])))))
+    (is (= [] (r/routes (r/router ["/ping" [nil "/pong"]])))))
 
   (testing "route coercion & compilation"
 
@@ -246,3 +246,9 @@
               [["/a"] ["/a"]]))))
     (testing "can be configured to ignore"
       (is (not (nil? (r/router [["/a"] ["/a"]] {:conflicts (constantly nil)})))))))
+
+(testing "nil routes are stripped"
+  (is (= [] (r/routes (r/router nil))))
+  (is (= [] (r/routes (r/router [nil ["/ping"]]))))
+  (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
+  (is (= [] (r/routes (r/router ["/ping" [nil "/pong"]])))))

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -246,9 +246,3 @@
               [["/a"] ["/a"]]))))
     (testing "can be configured to ignore"
       (is (not (nil? (r/router [["/a"] ["/a"]] {:conflicts (constantly nil)})))))))
-
-(testing "nil routes are stripped"
-  (is (= [] (r/routes (r/router nil))))
-  (is (= [] (r/routes (r/router [nil ["/ping"]]))))
-  (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
-  (is (= [] (r/routes (r/router ["/ping" [nil "/pong"]])))))

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -108,6 +108,12 @@
       r/segment-router :segment-router
       r/mixed-router :mixed-router))
 
+  (testing "nil routes are allowed ans stripped"
+    (is (= [] (r/routes (r/router nil))))
+    (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
+    (is (= [["/ping" {} nil]] (r/routes (r/router [nil [nil] ["/ping"]]))))
+    (is (= [["/ping" {} nil]] (r/routes (r/router [[[nil [nil] ["/ping"]]]])))))
+
   (testing "route coercion & compilation"
 
     (testing "custom compile"

--- a/test/cljc/reitit/ring_test.cljc
+++ b/test/cljc/reitit/ring_test.cljc
@@ -268,7 +268,7 @@
 
 #?(:clj
    (deftest resource-handler-test
-     (let [redirect (fn [uri] {:status 302 :headers {"Location" uri}})
+     (let [redirect (fn [uri] {:status 302, :body "", :headers {"Location" uri}})
            request (fn [uri] {:uri uri, :request-method :get})]
        (testing "inside a router"
 

--- a/test/cljc/reitit/ring_test.cljc
+++ b/test/cljc/reitit/ring_test.cljc
@@ -3,8 +3,7 @@
             [clojure.set :as set]
             [reitit.middleware :as middleware]
             [reitit.ring :as ring]
-            [reitit.core :as r]
-            [clojure.string :as str])
+            [reitit.core :as r])
   #?(:clj
      (:import (clojure.lang ExceptionInfo))))
 

--- a/test/cljc/reitit/spec_test.cljc
+++ b/test/cljc/reitit/spec_test.cljc
@@ -66,7 +66,7 @@
         {:conflicts (fn [_])}
         {:router r/linear-router})
 
-      #_(are [opts]
+      (are [opts]
         (is (thrown-with-msg?
               ExceptionInfo
               #"Call to #'reitit.core/router did not conform to spec"


### PR DESCRIPTION
... with these extra fixes, in this PR:

```markdown
### `reitit-core`

* Better handling of `nil` in route syntax:
  * explicit `nil` after path string is always handled as `nil` route
  * `nil` as path string causes the whole route to be `nil`
  * `nil` as child route is stripped away

(testing "nil routes are stripped"
  (is (= [] (r/routes (r/router nil))))
  (is (= [] (r/routes (r/router [nil ["/ping"]]))))
  (is (= [] (r/routes (r/router [nil [nil] [[nil nil nil]]]))))
  (is (= [] (r/routes (r/router ["/ping" [nil "/pong"]])))))

### `reitit-ring`

* Use HTTP redirect (302) with index-files in `reitit.ring/create-resource-handler`.
* `reitit.ring/create-default-handler` now conforms to [RING Spec](https://github.com/ring-clojure/ring/blob/master/SPEC), Fixes [#83](https://github.com/metosin/reitit/issues/83)
```