### PR TITLE
balance missing parens

### DIFF
--- a/examples/ring-swagger/src/example/server.clj
+++ b/examples/ring-swagger/src/example/server.clj
@@ -77,7 +77,7 @@
     (ring/routes
       (swagger-ui/create-swagger-ui-handler
         {:path "/"
-         :config {:validatorUrl nil})
+         :config {:validatorUrl nil}})
       (ring/create-default-handler))))
 
 (defn start []


### PR DESCRIPTION
The Swagger api example wasn't compiling as it was missing a paren, here is that missing paren in all its glory.