### PR TITLE
Support for top-level middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## `reitit-ring`
 
+* `ring-handler` takes optionally a 3rd argument, an options map which can be used to se top-level middleware, applied before any routing is done:
+
+```clj
+(require '[reitit.ring :as ring])
+
+(defn wrap [handler id]
+  (fn [request]
+    (handler (update request ::acc (fnil conj []) id))))
+
+(defn handler [{:keys [::acc]}]
+  {:status 200, :body (conj acc :handler)})
+
+(def app
+  (ring/ring-handler
+    (ring/router
+      ["/api" {:middleware [[mw :api]]}
+       ["/get" {:get handler}]])
+    (ring/create-default-handler)
+    {:middleware [[mw :top]]}))
+
+(app {:request-method :get, :uri "/api/get"})
+; {:status 200, :body [:top :api :ok]}
+
+(require '[reitit.core :as r])
+
+(-> app (ring/get-router))
+; #object[reitit.core$single_static_path_router]
+```
+
 * updated deps:
 
 ```clj

--- a/doc/ring/ring.md
+++ b/doc/ring/ring.md
@@ -127,6 +127,21 @@ Middleware is applied correctly:
 ; {:status 200, :body [:api :admin :db :delete :handler]}
 ```
 
+Top-level middleware, applied before any routing is done:
+
+```clj
+(def app
+  (ring/ring-handler
+    (ring/router
+      ["/api" {:middleware [[mw :api]]}
+       ["/get" {:get handler}]])
+    nil 
+    {:middleware [[mw :top]]}))
+
+(app {:request-method :get, :uri "/api/get"})
+; {:status 200, :body [:top :api :ok]}
+```
+
 # Async Ring
 
 All built-in middleware provide both 2 and 3-arity and are compiled for both Clojure & ClojureScript, so they work with [Async Ring](https://www.booleanknot.com/blog/2016/07/15/asynchronous-ring.html) and [Node.js](https://nodejs.org) too.

--- a/test/cljc/reitit/ring_test.cljc
+++ b/test/cljc/reitit/ring_test.cljc
@@ -78,6 +78,22 @@
           (is (= {:status 200, :body [:api :users :post :ok]}
                  @result))))))
 
+  (testing "with top-level middleware"
+    (let [router (ring/router
+                   ["/api" {:middleware [[mw :api]]}
+                    ["/get" {:get handler}]])
+          app (ring/ring-handler router nil {:middleware [[mw :top]]})]
+
+      (testing "router can be extracted"
+        (is (= router (ring/get-router app))))
+
+      (testing "not found"
+        (is (= nil (app {:uri "/favicon.ico"}))))
+
+      (testing "on match"
+        (is (= {:status 200, :body [:top :api :ok]}
+               (app {:uri "/api/get" :request-method :get}))))))
+
   (testing "named routes"
     (let [router (ring/router
                    [["/api"


### PR DESCRIPTION
* `ring-handler` takes optionally a 3rd argument, an options map which can be used to se top-level middleware, applied before any routing is done:

```clj
(require '[reitit.ring :as ring])

(defn wrap [handler id]
  (fn [request]
    (handler (update request ::acc (fnil conj []) id))))

(defn handler [{:keys [::acc]}]
  {:status 200, :body (conj acc :handler)})

(def app
  (ring/ring-handler
    (ring/router
      ["/api" {:middleware [[mw :api]]}
       ["/get" {:get handler}]])
    (ring/create-default-handler)
    {:middleware [[mw :top]]}))

(app {:request-method :get, :uri "/api/get"})
; {:status 200, :body [:top :api :ok]}

(require '[reitit.core :as r])

(-> app (ring/get-router))
; #object[reitit.core$single_static_path_router]
```