### PR TITLE
Fix reader conditional example

### DIFF
--- a/doc/advanced/shared_routes.md
+++ b/doc/advanced/shared_routes.md
@@ -17,8 +17,8 @@ There are multiple options to use shared routing table.
 (def routes
   ["/kikka"
    {:name ::kikka
-    :get #?(:clj {:handler get-kikka})
-    :post #?(:clj {:handler post-kikka})}])
+    #?@(:clj [:get {:handler get-kikka}])
+    #?@(:clj [:post {:handler post-kikka}])}])
 ```
 
 ## Using custom expander


### PR DESCRIPTION
The previous example only worked by accident (because there was an even number of map keys with conditional values).

{:get #?(:clj 1), :post #?(:clj 2)} gets read as {:get :post} in a non-clj context. The splicing reader conditional or a :cljs (or :default) value is needed to have the code work as intended. Here we change the docs to use the splicing version, as that is (imho) more beautiful than adding another branch.