### PR TITLE
Custom handler for resource 404

### DIFF
--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -160,11 +160,12 @@
      | :index-files     | optional vector of index-files to look in a resource directory, defaults to `[\"index.html\"]`"
      ([]
       (create-resource-handler nil))
-     ([{:keys [parameter root path loader allow-symlinks? index-files paths]
+     ([{:keys [parameter root path loader allow-symlinks? index-files paths not-found-handler]
         :or {parameter (keyword "")
              root "public"
              index-files ["index.html"]
-             paths (constantly nil)}}]
+             paths (constantly nil)
+             not-found-handler (constantly {:status 404, :body "", :headers {}})}}]
       (let [options {:root root, :loader loader, :allow-symlinks? allow-symlinks?}
             path-size (count path)
             create (fn [handler]
@@ -193,8 +194,7 @@
                         (let [uri (:uri request)
                               path (-> request :path-params parameter)]
                           (or (path-or-index-response path uri)
-                              ;; TODO: use generic not-found handler
-                              {:status 404}))))]
+                              (not-found-handler request)))))]
         (create handler)))))
 
 (defn ring-handler

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -151,13 +151,14 @@
    (defn create-resource-handler
      "A ring handler for serving classpath resources, configured via options:
 
-     | key              | description |
-     | -----------------|-------------|
-     | :parameter       | optional name of the wildcard parameter, defaults to unnamed keyword `:`
-     | :root            | optional resource root, defaults to `\"public\"`
-     | :path            | optional path to mount the handler to. Works only if mounted outside of a router.
-     | :loader          | optional class loader to resolve the resources
-     | :index-files     | optional vector of index-files to look in a resource directory, defaults to `[\"index.html\"]`"
+     | key                | description |
+     | -------------------|-------------|
+     | :parameter         | optional name of the wildcard parameter, defaults to unnamed keyword `:`
+     | :root              | optional resource root, defaults to `\"public\"`
+     | :path              | optional path to mount the handler to. Works only if mounted outside of a router.
+     | :loader            | optional class loader to resolve the resources
+     | :index-files       | optional vector of index-files to look in a resource directory, defaults to `[\"index.html\"]`
+     | :not-found-handler | optional handler function to use if the requested resource is missing (404 Not Found)"
      ([]
       (create-resource-handler nil))
      ([{:keys [parameter root path loader allow-symlinks? index-files paths not-found-handler]


### PR DESCRIPTION
## Issue
#89 

## Changes
Added optional `:not-found-handler` param to `create-resource-handler`.

It defaults to the same `constantly` as `create-default-handler` does.

## Tests
All current clj tests are green.

I didn't add tests for the new parameter -- should I? If so, to all the test branches (inside/outside router, root/path)?