### PR TITLE
Add step to verify cljdoc.edn as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
       - run:
           name: Run tests
           command: ./scripts/test.sh clj
+      - run:
+          name: Verify cljdoc.edn
+          command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
       - store_test_results:
           # path must be a directory under which there a subdirectories that
           # contain the JUnit XML files.


### PR DESCRIPTION
Hope this is useful in spotting discrepancies between Git state and `cljdoc.edn` :v: 

via https://github.com/cljdoc/cljdoc/issues/145