### PR TITLE
Add support for vector based specs in Swagger generation

### DIFF
--- a/modules/reitit-spec/src/reitit/coercion/spec.cljc
+++ b/modules/reitit-spec/src/reitit/coercion/spec.cljc
@@ -53,6 +53,11 @@
   (into-spec [this name]
     (dissoc (ds/spec (ensure-name name) this) :name))
 
+  #?(:clj  clojure.lang.PersistentVector
+     :cljs cljs.core.PersistentVector)
+  (into-spec [this name]
+    (dissoc (ds/spec (ensure-name name) this) :name))
+
   Maybe
   (into-spec [this name]
     (ds/spec (ensure-name name) this))


### PR DESCRIPTION
This allows data specs to be in vectors as well as maps. Before the change data spec [{:foo string?}] would throw exception when generating Swagger.