### PR TITLE
Decode path-params on match-by-name, fixes #192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `reitit-core`
 
 * `segment-router` doesn't accept empty segments as path-parameters, fixes [#181](https://github.com/metosin/reitit/issues/181).
+* path-params are decoded correctly with `r/match-by-name`, fixes [#192](https://github.com/metosin/reitit/issues/192).
 
 ## 0.2.9 (2018-11-21)
 

--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -176,7 +176,7 @@
                    (fn [[pl nl] [p {:keys [name] :as data} result]]
                      (let [{:keys [path-params] :as route} (impl/create [p data result])
                            f #(if-let [path (impl/path-for route %)]
-                                (->Match p data result % path)
+                                (->Match p data result (impl/url-decode-coll %) path)
                                 (->PartialMatch p data result % path-params))]
                        [(conj pl route)
                         (if name (assoc nl name f) nl)]))
@@ -266,7 +266,7 @@
                    (fn [[pl nl] [p {:keys [name] :as data} result]]
                      (let [{:keys [path-params] :as route} (impl/create [p data result])
                            f #(if-let [path (impl/path-for route %)]
-                                (->Match p data result % path)
+                                (->Match p data result (impl/url-decode-coll %) path)
                                 (->PartialMatch p data result % path-params))]
                        [(segment/insert pl p (->Match p data result nil nil))
                         (if name (assoc nl name f) nl)]))

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -52,12 +52,14 @@
                     (r/match-by-name! router ::beer))))))
 
         (testing "decode %-encoded path params"
-          (let [router (r/router [["/one-param-path/:param1"]
+          (let [router (r/router [["/one-param-path/:param1" ::one]
                                   ["/two-param-path/:param1/:param2"]
                                   ["/catchall/*remaining-path"]] {:router r})
                 decoded-params #(-> router (r/match-by-path %) :path-params)
                 decoded-param1 #(-> (decoded-params %) :param1)
                 decoded-remaining-path #(-> (decoded-params %) :remaining-path)]
+            (is (= {:param1 "käki"} (:path-params (r/match-by-name router ::one {:param1 "käki"}))))
+            (is (= "/one-param-path/k%C3%A4ki" (:path (r/match-by-name router ::one {:param1 "käki"}))))
             (is (= "foo bar" (decoded-param1 "/one-param-path/foo%20bar")))
             (is (= {:param1 "foo bar" :param2 "baz qux"} (decoded-params "/two-param-path/foo%20bar/baz%20qux")))
             (is (= "foo bar" (decoded-remaining-path "/catchall/foo%20bar")))


### PR DESCRIPTION
```clj
(-> (r/router ["/kohta/:on/:joulu" ::joulu])
    (r/match-by-name ::joulu {:on "käki", :joulu "kärsii"}))
;#Match{:template "/kohta/:on/:joulu",
;       :data {:name :user/joulu},
;       :result nil,
;       :path-params {:on "käki", :joulu "kärsii"},
;       :path "/kohta/k%C3%A4ki/k%C3%A4rsii"}
```