### PR TITLE
minor fix: added missing dependency

### DIFF
--- a/examples/ring-spec-swagger/project.clj
+++ b/examples/ring-spec-swagger/project.clj
@@ -3,4 +3,5 @@
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [ring/ring-jetty-adapter "1.7.0"]
                  [metosin/reitit "0.2.10"]]
-  :repl-options {:init-ns example.server})
+  :repl-options {:init-ns example.server}
+  :profiles{:dev {:dependencies [[ring/ring-mock "0.3.2"]]}})


### PR DESCRIPTION
ring-mock is needed to run `lein test`at  examples/ring-spec-swagger