### PR TITLE
Fix handling links inside contenteditable

### DIFF
--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -2,7 +2,8 @@
   (:require [reitit.core :as reitit]
             [reitit.core :as r]
             [reitit.frontend :as rf]
-            [goog.events :as gevents])
+            [goog.events :as gevents]
+            [goog.dom :as gdom])
   (:import goog.Uri))
 
 (defprotocol History
@@ -75,7 +76,8 @@
                            (not (contains? #{"_blank" "self"} (.getAttribute el "target")))
                            ;; Left button
                            (= 0 (.-button e))
-                           (reitit/match-by-path router (.getPath uri)))
+                           (reitit/match-by-path router (.getPath uri))
+                           (not (gdom/getAncestor el (fn [node] (.isContentEditable node)))))
                   (.preventDefault e)
                   (let [path (str (.getPath uri)
                                   (if (seq (.getQuery uri))


### PR DESCRIPTION
The default click behavior inside a container that is `contenteditable` is to not follow the link so that the link’s text stays selectable and editable. 

See [this jsfiddle](http://jsfiddle.net/gtewd276/1/) that shows a `div[contenteditable]` with a link inside it.

The current reitit behavior is to try to follow the link when it’s route is supported. This PR adds an exception to not follow them when they are nested inside a `contenteditable`.