### PR TITLE
Point each project.clj to the git directory

### DIFF
--- a/modules/reitit-core/project.clj
+++ b/modules/reitit-core/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-frontend/project.clj
+++ b/modules/reitit-frontend/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-http/project.clj
+++ b/modules/reitit-http/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-interceptors/project.clj
+++ b/modules/reitit-interceptors/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-middleware/project.clj
+++ b/modules/reitit-middleware/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :scm "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-pedestal/project.clj
+++ b/modules/reitit-pedestal/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-ring/project.clj
+++ b/modules/reitit-ring/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-schema/project.clj
+++ b/modules/reitit-schema/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-sieppari/project.clj
+++ b/modules/reitit-sieppari/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-spec/project.clj
+++ b/modules/reitit-spec/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-swagger-ui/project.clj
+++ b/modules/reitit-swagger-ui/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit-swagger/project.clj
+++ b/modules/reitit-swagger/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}

--- a/modules/reitit/project.clj
+++ b/modules/reitit/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git"
-        :url "https://github.com/metosin/reitit"}
+        :url "https://github.com/metosin/reitit"
+        :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}


### PR DESCRIPTION
This way the released JARs should include the git commit they were built from. That is, the "this commit" link on [Clojars](https://clojars.org/metosin/reitit) starts to work.