### PR TITLE
Extract swagger spec generation logic from `create-swagger-handler`

### DIFF
--- a/test/cljc/reitit/swagger_test.clj
+++ b/test/cljc/reitit/swagger_test.clj
@@ -1,5 +1,6 @@
 (ns reitit.swagger-test
   (:require [clojure.test :refer :all]
+            [reitit.core :as r]
             [reitit.ring :as ring]
             [reitit.swagger :as swagger]
             [reitit.swagger-ui :as swagger-ui]
@@ -80,21 +81,47 @@
                {:request-method :get
                 :uri "/api/schema/plus/3"
                 :query-params {:x "2", :y "1"}})))))
-  (testing "swagger-spec"
-    (let [spec (:body (app
-                        {:request-method :get
-                         :uri "/api/swagger.json"}))
-          expected {:x-id #{::math}
-                    :swagger "2.0"
-                    :info {:title "my-api"}
-                    :paths {"/api/schema/plus/{z}" {:get {:parameters [{:description ""
-                                                                        :format "int32"
+
+  (testing "swagger spec"
+    (let [expected {:x-id #{::math}
+                      :swagger "2.0"
+                      :info {:title "my-api"}
+                      :paths {"/api/schema/plus/{z}" {:get {:parameters [{:description ""
+                                                                          :format "int32"
+                                                                          :in "query"
+                                                                          :name "x"
+                                                                          :required true
+                                                                          :type "integer"}
+                                                                         {:description ""
+                                                                          :format "int32"
+                                                                          :in "query"
+                                                                          :name "y"
+                                                                          :required true
+                                                                          :type "integer"}
+                                                                         {:in "path"
+                                                                          :name "z"
+                                                                          :description ""
+                                                                          :type "integer"
+                                                                          :required true
+                                                                          :format "int32"}]
+                                                            :responses {200 {:description ""
+                                                                             :schema {:additionalProperties false
+                                                                                      :properties {"total" {:format "int32"
+                                                                                                            :type "integer"}}
+                                                                                      :required ["total"]
+                                                                                      :type "object"}}
+                                                                        400 {:schema {:type "string"}
+                                                                             :description "kosh"}
+                                                                        500 {:description "fail"}}
+                                                            :summary "plus"}}
+                              "/api/spec/plus/{z}" {:get {:parameters [{:description ""
+                                                                        :format "int64"
                                                                         :in "query"
                                                                         :name "x"
                                                                         :required true
                                                                         :type "integer"}
                                                                        {:description ""
-                                                                        :format "int32"
+                                                                        :format "int64"
                                                                         :in "query"
                                                                         :name "y"
                                                                         :required true
@@ -104,74 +131,58 @@
                                                                         :description ""
                                                                         :type "integer"
                                                                         :required true
-                                                                        :format "int32"}]
+                                                                        :format "int64"}]
                                                           :responses {200 {:description ""
-                                                                           :schema {:additionalProperties false
-                                                                                    :properties {"total" {:format "int32"
+                                                                           :schema {:properties {"total" {:format "int64"
                                                                                                           :type "integer"}}
                                                                                     :required ["total"]
                                                                                     :type "object"}}
                                                                       400 {:schema {:type "string"}
                                                                            :description "kosh"}
                                                                       500 {:description "fail"}}
-                                                          :summary "plus"}}
-                            "/api/spec/plus/{z}" {:get {:parameters [{:description ""
-                                                                      :format "int64"
-                                                                      :in "query"
-                                                                      :name "x"
-                                                                      :required true
-                                                                      :type "integer"}
-                                                                     {:description ""
-                                                                      :format "int64"
-                                                                      :in "query"
-                                                                      :name "y"
-                                                                      :required true
-                                                                      :type "integer"}
-                                                                     {:in "path"
-                                                                      :name "z"
-                                                                      :description ""
-                                                                      :type "integer"
-                                                                      :required true
-                                                                      :format "int64"}]
-                                                        :responses {200 {:description ""
-                                                                         :schema {:properties {"total" {:format "int64"
-                                                                                                        :type "integer"}}
-                                                                                  :required ["total"]
-                                                                                  :type "object"}}
-                                                                    400 {:schema {:type "string"}
-                                                                         :description "kosh"}
-                                                                    500 {:description "fail"}}
-                                                        :summary "plus"}
-                                                  :post {:parameters [{:in "body",
-                                                                       :name "",
-                                                                       :description "",
-                                                                       :required true,
-                                                                       :schema {:type "array",
-                                                                                :items {:type "integer",
-                                                                                        :format "int64"}}}
-                                                                      {:in "path"
-                                                                       :name "z"
-                                                                       :description ""
-                                                                       :type "integer"
-                                                                       :required true
-                                                                       :format "int64"}]
-                                                         :responses {200 {:description ""
-                                                                          :schema {:properties {"total" {:format "int64"
-                                                                                                         :type "integer"}}
-                                                                                   :required ["total"]
-                                                                                   :type "object"}}
-                                                                     400 {:schema {:type "string"}
-                                                                          :description "kosh"}
-                                                                     500 {:description "fail"}}
-                                                         :summary "plus with body"}}}}]
-      (is (= expected spec))
+                                                          :summary "plus"}
+                                                    :post {:parameters [{:in "body",
+                                                                         :name "",
+                                                                         :description "",
+                                                                         :required true,
+                                                                         :schema {:type "array",
+                                                                                  :items {:type "integer",
+                                                                                          :format "int64"}}}
+                                                                        {:in "path"
+                                                                         :name "z"
+                                                                         :description ""
+                                                                         :type "integer"
+                                                                         :required true
+                                                                         :format "int64"}]
+                                                           :responses {200 {:description ""
+                                                                            :schema {:properties {"total" {:format "int64"
+                                                                                                           :type "integer"}}
+                                                                                     :required ["total"]
+                                                                                     :type "object"}}
+                                                                       400 {:schema {:type "string"}
+                                                                            :description "kosh"}
+                                                                       500 {:description "fail"}}
+                                                           :summary "plus with body"}}}}]
 
-      (testing "ring-async swagger-spec"
-        (let [response* (atom nil)
-              respond (partial reset! response*)]
-          (app {:request-method :get
-                :uri "/api/swagger.json"} respond (fn [_] (is false)))
-          (is (= expected (:body @response*))))))))
+      (testing "swagger spec generation"
+        (let [router (ring/get-router app)
+              swagger-data (-> (r/match-by-path router "/api/swagger.json")
+                               (get-in [:result :get :data :swagger]))
+              compiled-routes (r/compiled-routes router)
+              spec (swagger/swagger-spec swagger-data compiled-routes)]
+          (is (= expected spec))))
+
+      (testing "swagger spec endpoints"
+        (testing "sync"
+          (let [spec (:body (app {:request-method :get
+                                  :uri "/api/swagger.json"}))]
+            (is (= expected spec))))
+        (testing "async"
+          (let [response* (atom nil)
+                respond (partial reset! response*)]
+            (app {:request-method :get
+                  :uri "/api/swagger.json"} respond (fn [_] (is false)))
+            (is (= expected (:body @response*)))))))))
 
 (defn spec-paths [app uri]
   (-> {:request-method :get, :uri uri} app :body :paths keys))


### PR DESCRIPTION
Fixes https://github.com/metosin/reitit/issues/246

This extracts the logic for doing the swagger 2.0 spec creation from the `reitit.swagger/create-swagger-handler` as a public api `(reitit.swagger/swagger-spec compiled-routes swagger-data)`.