### PR TITLE
Remove unused compojure dependencies from frontend examples

### DIFF
--- a/examples/frontend-auth/project.clj
+++ b/examples/frontend-auth/project.clj
@@ -8,7 +8,6 @@
                  [ring-server "0.5.0"]
                  [reagent "0.8.1"]
                  [ring "1.7.1"]
-                 [compojure "1.6.1"]
                  [hiccup "1.0.5"]
                  [org.clojure/clojurescript "1.10.439"]
                  [metosin/reitit "0.3.1"]

--- a/examples/frontend-controllers/project.clj
+++ b/examples/frontend-controllers/project.clj
@@ -8,7 +8,6 @@
                  [ring-server "0.5.0"]
                  [reagent "0.8.1"]
                  [ring "1.7.1"]
-                 [compojure "1.6.1"]
                  [hiccup "1.0.5"]
                  [org.clojure/clojurescript "1.10.439"]
                  [metosin/reitit "0.3.1"]

--- a/examples/frontend/project.clj
+++ b/examples/frontend/project.clj
@@ -8,7 +8,6 @@
                  [ring-server "0.5.0"]
                  [reagent "0.8.1"]
                  [ring "1.7.1"]
-                 [compojure "1.6.1"]
                  [hiccup "1.0.5"]
                  [org.clojure/clojurescript "1.10.439"]
                  [metosin/reitit "0.3.1"]


### PR DESCRIPTION
These don't appear to be needed and might cause users to introduce
dependencies into their projects if they use as templates in their own
projects.