### PR TITLE
Fix: Ignore anchors with any target value except empty or _self

### DIFF
--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -84,7 +84,7 @@
                            (not (.-ctrlKey e))
                            (not (.-metaKey e))
                            (not (.-shiftKey e))
-                           (not (contains? #{"_blank" "self"} (.getAttribute el "target")))
+                           (not (contains? #{"_blank" "_self"} (.getAttribute el "target")))
                            ;; Left button
                            (= 0 (.-button e))
                            ;; isContentEditable property is inherited from parents,

--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -84,7 +84,8 @@
                            (not (.-ctrlKey e))
                            (not (.-metaKey e))
                            (not (.-shiftKey e))
-                           (not (contains? #{"_blank" "_self"} (.getAttribute el "target")))
+                           (or (not (.hasAttribute el "target"))
+                               (contains? #{"" "_self"} (.getAttribute el "target")))
                            ;; Left button
                            (= 0 (.-button e))
                            ;; isContentEditable property is inherited from parents,


### PR DESCRIPTION
We should probably ignore `_parent` and `_top` as well?

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a

