### PR TITLE
Support html5 links inside Shadow DOM

### DIFF
--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -60,8 +60,8 @@
           (recur (.-parentNode el)))))))
 
 (defn- event-target [event]
-  ;; Read event's target from composed path to get shadow dom working,
-  ;; fallback to target property if not available
+  "Read event's target from composed path to get shadow dom working,
+   fallback to target property if not available"
   (let [original-event (.-event_ event)]
     (if (exists? (.-composedPath original-event))
       (first (.composedPath original-event))

--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -62,7 +62,7 @@
 (defn- event-target [event]
   "Read event's target from composed path to get shadow dom working,
    fallback to target property if not available"
-  (let [original-event (.-event_ event)]
+  (let [original-event (.getBrowserEvent event)]
     (if (exists? (.-composedPath original-event))
       (first (.composedPath original-event))
       (.-target event))))

--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -59,6 +59,14 @@
           el
           (recur (.-parentNode el)))))))
 
+(defn- event-target [event]
+  ;; Read event's target from composed path to get shadow dom working,
+  ;; fallback to target property if not available
+  (let [original-event (.-event_ event)]
+    (if (exists? (.-composedPath original-event))
+      (first (.composedPath original-event))
+      (.-target event))))
+
 (defrecord Html5History [on-navigate router listen-key click-listen-key]
   History
   (-init [this]
@@ -76,7 +84,7 @@
           (fn ignore-anchor-click
             [e]
             ;; Returns the next matching anchestor of event target
-            (when-let [el (closest-by-tag (.-target e) "a")]
+            (when-let [el (closest-by-tag (event-target e) "a")]
               (let [uri (.parse Uri (.-href el))]
                 (when (and (or (and (not (.hasScheme uri)) (not (.hasDomain uri)))
                                (= current-domain (.getDomain uri)))


### PR DESCRIPTION
We are using web components so we needed to get html5 links inside shadow dom. So we needed to get correct target element from MouseEvent's composedPath() instead of just using the target property. 

We also added a test that clicks links to test this. Test will fail with "Some of your tests did a full page reload!" if test fails.

If you want any changes to this, I'm happy to help!