### PR TITLE
Better errors for route-data merge errors

### DIFF
--- a/modules/reitit-core/src/reitit/exception.cljc
+++ b/modules/reitit-core/src/reitit/exception.cljc
@@ -35,3 +35,6 @@
            (fn [[name vals]]
              (str name "\n-> " (str/join "\n-> " (mapv first vals)) "\n"))
            conflicts)))
+
+(defmethod format-exception :reitit.impl/merge-data [_ _ data]
+  (str "Error merging route-data\n\n" (pr-str data)))

--- a/modules/reitit-core/src/reitit/exception.cljc
+++ b/modules/reitit-core/src/reitit/exception.cljc
@@ -7,11 +7,14 @@
   ([type data]
    (throw (ex-info (str type) {:type type, :data data}))))
 
+(defn get-message [e]
+  #?(:clj (.getMessage ^Exception e) :cljs (ex-message e)))
+
 (defmulti format-exception (fn [type _ _] type))
 
 (defn exception [e]
   (let [data (ex-data e)
-        message (format-exception (:type data) #?(:clj (.getMessage ^Exception e) :cljs (ex-message e)) (:data data))]
+        message (format-exception (:type data) (get-message e) (:data data))]
     ;; there is a 3-arity version (+cause) of ex-info, but the default repl error message is taken from the cause
     (ex-info message (assoc (or data {}) ::cause e))))
 

--- a/modules/reitit-dev/src/reitit/dev/pretty.cljc
+++ b/modules/reitit-dev/src/reitit/dev/pretty.cljc
@@ -335,3 +335,27 @@
        problems))
    (color :white "https://cljdoc.org/d/metosin/reitit/CURRENT/doc/basics/route-data-validation")
    [:break]])
+
+(defmethod format-exception :reitit.impl/merge-data [_ _ {:keys [path left right exception]}]
+  [:group
+   (text "Error merging route-data:")
+   [:break] [:break]
+   [:group
+    [:span (color :grey "-- On route -----------------------")]
+    [:break]
+    [:break]
+    (text path)
+    [:break]
+    [:break]
+    [:span (color :grey "-- Exception ----------------------")]
+    [:break]
+    [:break]
+    (color :red (ex-message exception))
+    [:break]
+    [:break]
+    (edn left {:margin 3})
+    [:break]
+    (edn right {:margin 3})]
+   [:break]
+   (color :white "https://cljdoc.org/d/metosin/reitit/0.3.1/doc/basics/route-data")
+   [:break]])

--- a/modules/reitit-dev/src/reitit/dev/pretty.cljc
+++ b/modules/reitit-dev/src/reitit/dev/pretty.cljc
@@ -350,7 +350,7 @@
     [:span (color :grey "-- Exception ----------------------")]
     [:break]
     [:break]
-    (color :red (ex-message exception))
+    (color :red (exception/get-message exception))
     [:break]
     [:break]
     (edn left {:margin 3})

--- a/modules/reitit-dev/src/reitit/dev/pretty.cljc
+++ b/modules/reitit-dev/src/reitit/dev/pretty.cljc
@@ -357,5 +357,5 @@
     [:break]
     (edn right {:margin 3})]
    [:break]
-   (color :white "https://cljdoc.org/d/metosin/reitit/0.3.1/doc/basics/route-data")
+   (color :white "https://cljdoc.org/d/metosin/reitit/CURRENT/doc/basics/route-data")
    [:break]])

--- a/test/cljc/reitit/exception_test.cljc
+++ b/test/cljc/reitit/exception_test.cljc
@@ -43,7 +43,11 @@
       ["/api/{ipa"]
 
       #"Invalid route data"
-      ["/api/ipa" {::roles #{:adminz}}])
+      ["/api/ipa" {::roles #{:adminz}}]
+
+      #"Error merging route-data"
+      ["/a" {:body {}}
+       ["/b" {:body [:FAIL]}]])
 
     exception/exception
     pretty/exception))


### PR DESCRIPTION
```clj
(ns user
  (:require [reitit.core :as r]
            [schema.core :as s]
            [reitit.dev.pretty :as pretty]))

(r/router
  ["/kikka"
   {:parameters {:body {:id s/Str}}}
   ["/kakka"
    {:parameters {:body [s/Str]}}]]
  {:exception pretty/exception})
```
=>

<img width="745" alt="Screenshot 2019-05-15 at 22 53 28" src="https://user-images.githubusercontent.com/567532/57804936-89921d00-7764-11e9-9965-09d5c30372b8.png">
