### PR TITLE
Properly access ::s/problems key in coercion-spec

### DIFF
--- a/modules/reitit-spec/src/reitit/coercion/spec.cljc
+++ b/modules/reitit-spec/src/reitit/coercion/spec.cljc
@@ -110,7 +110,7 @@
       (into-spec model name))
     (-open-model [_ spec] spec)
     (-encode-error [_ error]
-      (let [problems (::s/problems error)]
+      (let [problems (-> error :problems ::s/problems)]
         (-> error
             (update :spec (comp str s/form))
             (assoc :problems (mapv #(update % :pred stringify-pred) problems)))))

--- a/test/cljc/reitit/ring_coercion_test.cljc
+++ b/test/cljc/reitit/ring_coercion_test.cljc
@@ -95,7 +95,9 @@
                  (app valid-request))))
 
         (testing "invalid request"
-          (let [{:keys [status]} (app invalid-request)]
+          (let [{:keys [status body]} (app invalid-request)
+                problems (:problems body)]
+            (is (= 1 (count problems)))
             (is (= 400 status))))
 
         (testing "invalid response"


### PR DESCRIPTION
## Problem

When making an API request with a payload that doesn't conform to the defined spec, I receive a `400` error, but the `problems` key contains an empty vector instead of a problem description.

## Solution

It seems that we're trying to access the `::s/problems` key from `error`, however this is wrapped within another `:problems` key. When accessing the nested key the issue is resolved.

## Notes

I'm not sure if this is the correct solution, maybe the key shouldn't be nested in the first place?