### PR TITLE
[#283] Allow to pass some defaults to create-default-handler

### DIFF
--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -143,14 +143,14 @@
   | key                    | description |
   | -----------------------|-------------|
   | `:not-found`           | 404, no routes matches
-  | `:method-not-accepted` | 405, no method matches
+  | `:method-not-allowed`  | 405, no method matches
   | `:not-acceptable`      | 406, handler returned `nil`"
   ([]
-   (create-default-handler
-     {:not-found (constantly {:status 404, :body "", :headers {}})
-      :method-not-allowed (constantly {:status 405, :body "", :headers {}})
-      :not-acceptable (constantly {:status 406, :body "", :headers {}})}))
-  ([{:keys [not-found method-not-allowed not-acceptable]}]
+   (create-default-handler {}))
+  ([{:keys [not-found method-not-allowed not-acceptable]
+     :or {not-found (constantly {:status 404, :body "", :headers {}})
+          method-not-allowed (constantly {:status 405, :body "", :headers {}})
+          not-acceptable (constantly {:status 406, :body "", :headers {}})}}]
    (fn
      ([request]
       (if-let [match (::r/match request)]

--- a/test/cljc/reitit/ring_test.cljc
+++ b/test/cljc/reitit/ring_test.cljc
@@ -161,8 +161,8 @@
 (deftest default-handler-test
   (let [response {:status 200, :body "ok"}
         router (ring/router
-                 [["/ping" {:get (constantly response)}]
-                  ["/pong" (constantly nil)]])
+                [["/ping" {:get (constantly response)}]
+                 ["/pong" (constantly nil)]])
         app (ring/ring-handler router)]
 
     (testing "match"
@@ -188,15 +188,21 @@
 
       (testing "with custom http responses"
         (let [app (ring/ring-handler router (ring/create-default-handler
-                                              {:not-found (constantly {:status -404})
-                                               :method-not-allowed (constantly {:status -405})
-                                               :not-acceptable (constantly {:status -406})}))]
+                                             {:not-found (constantly {:status -404})
+                                              :method-not-allowed (constantly {:status -405})
+                                              :not-acceptable (constantly {:status -406})}))]
           (testing "route doesn't match"
             (is (= -404 (:status (app {:request-method :get, :uri "/"})))))
           (testing "method doesn't match"
             (is (= -405 (:status (app {:request-method :post, :uri "/ping"})))))
           (testing "handler rejects"
-            (is (= -406 (:status (app {:request-method :get, :uri "/pong"}))))))))))
+            (is (= -406 (:status (app {:request-method :get, :uri "/pong"})))))))
+
+      (testing "with some custom http responses"
+        (let [app (ring/ring-handler router (ring/create-default-handler
+                                             {:not-found (constantly {:status -404})}))]
+          (testing "route doesn't match"
+            (is (= 405 (:status (app {:request-method :post, :uri "/ping"}))))))))))
 
 (deftest default-options-handler-test
   (let [response {:status 200, :body "ok"}]


### PR DESCRIPTION
To allow only to pass in a :not-found handler to the (ring/create-default-handler)