### PR TITLE
Check also pedestal interceptor key values, fixes #285

### DIFF
--- a/examples/pedestal-swagger/src/example/server.clj
+++ b/examples/pedestal-swagger/src/example/server.clj
@@ -6,6 +6,7 @@
             [reitit.swagger :as swagger]
             [reitit.swagger-ui :as swagger-ui]
             [reitit.http.coercion :as coercion]
+            [reitit.dev.pretty :as pretty]
             [reitit.http.interceptors.parameters :as parameters]
             [reitit.http.interceptors.muuntaja :as muuntaja]
             [reitit.http.interceptors.exception :as exception]
@@ -126,12 +127,12 @@
                                 {:default-src "'self'"
                                  :style-src "'self' 'unsafe-inline'"
                                  :script-src "'self' 'unsafe-inline'"}}}
-      (io.pedestal.http/default-interceptors)
+      (server/default-interceptors)
       ;; use the reitit router
       (pedestal/replace-last-interceptor router)
-      (io.pedestal.http/dev-interceptors)
-      (io.pedestal.http/create-server)
-      (io.pedestal.http/start))
+      (server/dev-interceptors)
+      (server/create-server)
+      (server/start))
   (println "server running in port 3000"))
 
 (comment

--- a/modules/reitit-pedestal/src/reitit/pedestal.clj
+++ b/modules/reitit-pedestal/src/reitit/pedestal.clj
@@ -34,7 +34,7 @@
   (cond
     (interceptor/interceptor? interceptor)
     interceptor
-    (seq (select-keys interceptor [:enter :leave :error]))
+    (->> (select-keys interceptor [:enter :leave :error]) (vals) (keep identity) (seq))
     (interceptor/interceptor
       (if (error-without-arity-2? interceptor)
         (wrap-error-arity-2->1 interceptor)

--- a/test/clj/reitit/pedestal_test.clj
+++ b/test/clj/reitit/pedestal_test.clj
@@ -33,11 +33,7 @@
                     {:interceptors [{:name :nop} (exception/exception-interceptor)]}
                     ["/ok" (fn [_] {:status 200, :body "ok"})]
                     ["/fail" (fn [_] (throw (ex-info "kosh" {})))]]))
-        service (-> {:env :dev
-                     :io.pedestal.http/type :jetty
-                     :io.pedestal.http/port 3000
-                     :io.pedestal.http/join? false
-                     :io.pedestal.http/request-logger nil
+        service (-> {:io.pedestal.http/request-logger nil
                      :io.pedestal.http/routes []}
                     (io.pedestal.http/default-interceptors)
                     (pedestal/replace-last-interceptor router)

--- a/test/clj/reitit/pedestal_test.clj
+++ b/test/clj/reitit/pedestal_test.clj
@@ -1,6 +1,10 @@
 (ns reitit.pedestal-test
   (:require [clojure.test :refer [deftest testing is]]
-            [reitit.pedestal :as pedestal]))
+            [io.pedestal.test]
+            [io.pedestal.http]
+            [reitit.http :as http]
+            [reitit.pedestal :as pedestal]
+            [reitit.http.interceptors.exception :as exception]))
 
 (deftest arities-test
   (is (= #{0} (#'pedestal/arities (fn []))))
@@ -21,3 +25,23 @@
       (is (has-2-arity-error? {:error (fn [_ _])}))
       (is (has-2-arity-error? {:error (fn [_ _ _])}))
       (is (has-2-arity-error? {:error (fn ([_]) ([_ _]))})))))
+
+(deftest pedestal-e2e-test
+  (let [router (pedestal/routing-interceptor
+                 (http/router
+                   [""
+                    {:interceptors [{:name :nop} (exception/exception-interceptor)]}
+                    ["/ok" (fn [_] {:status 200, :body "ok"})]
+                    ["/fail" (fn [_] (throw (ex-info "kosh" {})))]]))
+        service (-> {:env :dev
+                     :io.pedestal.http/type :jetty
+                     :io.pedestal.http/port 3000
+                     :io.pedestal.http/join? false
+                     :io.pedestal.http/request-logger nil
+                     :io.pedestal.http/routes []}
+                    (io.pedestal.http/default-interceptors)
+                    (pedestal/replace-last-interceptor router)
+                    (io.pedestal.http/create-servlet)
+                    (:io.pedestal.http/service-fn))]
+    (is (= "ok" (:body (io.pedestal.test/response-for service :get "/ok"))))
+    (is (= 500 (:status (io.pedestal.test/response-for service :get "/fail"))))))


### PR DESCRIPTION
Reitit coerces interceptors into Records, so the keys are always there, but the values can be `nil`.