### PR TITLE
Correct doc (obsolete example of middleware/create)

### DIFF
--- a/doc/ring/data_driven_middleware.md
+++ b/doc/ring/data_driven_middleware.md
@@ -53,7 +53,7 @@ The following produce identical middleware runtime function.
 (require '[reitit.middleware :as middleware])
 
 (def wrap2
-  (middleware/create
+  (middleware/map->Middleware
     {:name ::wrap2
      :description "Middleware that does things."
      :wrap wrap}))


### PR DESCRIPTION
`reitit.middleware/create `has been removed at [927d4d43](https://github.com/metosin/reitit/commit/927d4d43).
It seems `reitit.middleware/map->Middleware` is the right approach
instead.

More:
https://clojurians.slack.com/archives/C7YF1SBT3/p1561635497233300