### PR TITLE
Pass uri fragments to history pushState

### DIFF
--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -101,8 +101,10 @@
                            (reitit/match-by-path router (.getPath uri)))
                   (.preventDefault e)
                   (let [path (str (.getPath uri)
-                                  (if (seq (.getQuery uri))
-                                    (str "?" (.getQuery uri))))]
+                                  (when (.hasQuery uri)
+                                    (str "?" (.getQuery uri)))
+                                  (when (.hasFragment uri)
+                                    (str "#" (.getFragment uri))))]
                     (.pushState js/window.history nil "" path)
                     (-on-navigate this path))))))]
       (-on-navigate this (-get-path this))


### PR DESCRIPTION
This fixes an issue where clicking a link handled by `reitit.frontend.history/Html5History`, which contains a `#` fragment, the fragment would be discarded upon navigation.