### PR TITLE
Use aget for composedPath to avoid casting JS array to seq

### DIFF
--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -64,7 +64,7 @@
    fallback to target property if not available"
   (let [original-event (.getBrowserEvent event)]
     (if (exists? (.-composedPath original-event))
-      (first (.composedPath original-event))
+      (aget (.composedPath original-event) 0)
       (.-target event))))
 
 (defrecord Html5History [on-navigate router listen-key click-listen-key]


### PR DESCRIPTION
When running our Cypress tests, `(first (.composedPath original-event))` (see commit) throws the error `... is not ISeqable`.

```
Uncaught Error: http://localhost:5000/default/regions,[object HTMLLIElement],[object HTMLUListElement],[object HTMLElement],[object HTMLDivElement],[object HTMLDivElement],[object HTMLBodyElement],[object HTMLHtmlElement],[object HTMLDocument],[object Window] is not ISeqable

This error originated from your application code, not from Cypress.

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the 'uncaught:exception' event.

https://on.cypress.io/uncaught-exception-from-application
    at Object.cljs$core$seq [as seq] (http://localhost:5000/js/compiled/cljs/core.js:4442:8)
    at cljs$core$first (http://localhost:5000/js/compiled/cljs/core.js:4461:19)
    at reitit$frontend$history$event_target (http://localhost:5000/js/compiled/reitit/frontend/history.js:433:24)
    at HTMLDocument.reitit$frontend$history$ignore_anchor_click (http://localhost:5000/js/compiled/reitit/frontend/history.js:588:112)
    at Object.goog.events.fireListener (http://localhost:5000/js/compiled/goog/events/events.js:744:21)
    at HTMLDocument.goog.events.handleBrowserEvent_ (http://localhost:5000/js/compiled/goog/events/events.js:870:22)
    at HTMLDocument.f (http://localhost:5000/js/compiled/goog/events/events.js:289:38)
 ,,,
```

I'm not sure if this error is reproducible outside of Cypress tests; regular usage doesn't throw this error. But in addition to fixing this specific error, it seems like using `aget` instead of `first` here would be more semantic (and perhaps marginally faster as well?).