### PR TITLE
Make Map Destructuring of Namespaced Keys more Beautiful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -539,7 +539,7 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
   (fn [request]
     (handler (update request ::acc (fnil conj []) id))))
 
-(defn handler [{:keys [::acc]}]
+(defn handler [{::keys [acc]}]
   {:status 200, :body (conj acc :handler)})
 
 (def app

--- a/doc/ring/data_driven_middleware.md
+++ b/doc/ring/data_driven_middleware.md
@@ -66,7 +66,7 @@ The following produce identical middleware runtime function.
 ```clj
 (require '[reitit.ring :as ring])
 
-(defn handler [{:keys [::acc]}]
+(defn handler [{::keys [acc]}]
   {:status 200, :body (conj acc :handler)})
 
 (def app

--- a/doc/ring/dynamic_extensions.md
+++ b/doc/ring/dynamic_extensions.md
@@ -9,7 +9,7 @@ Example middleware to guard routes based on user roles:
 (require '[clojure.set :as set])
 
 (defn wrap-enforce-roles [handler]
-  (fn [{:keys [::roles] :as request}]
+  (fn [{::keys [roles] :as request}]
     (let [required (some-> request (ring/get-match) :data ::roles)]
       (if (and (seq required) (not (set/subset? required roles)))
         {:status 403, :body "forbidden"}

--- a/doc/ring/reverse_routing.md
+++ b/doc/ring/reverse_routing.md
@@ -12,7 +12,7 @@ Below is an example how to do reverse routing from a ring handler:
   (ring/ring-handler
     (ring/router
       [["/users"
-        {:get (fn [{:keys [::r/router]}]
+        {:get (fn [{::r/keys [router]}]
                 {:status 200
                  :body (for [i (range 10)]
                          {:uri (-> router

--- a/doc/ring/ring.md
+++ b/doc/ring/ring.md
@@ -155,7 +155,7 @@ A middleware and a handler:
   (fn [request]
     (handler (update request ::acc (fnil conj []) id))))
 
-(defn handler [{:keys [::acc]}]
+(defn handler [{::keys [acc]}]
   {:status 200, :body (conj acc :handler)})
 ```
 

--- a/doc/ring/route_data_validation.md
+++ b/doc/ring/route_data_validation.md
@@ -155,7 +155,7 @@ Let's reuse the `wrap-enforce-roles` from [Dynamic extensions](dynamic_extension
 (s/def ::roles (s/coll-of ::role :into #{}))
 
 (defn wrap-enforce-roles [handler]
-  (fn [{:keys [::roles] :as request}]
+  (fn [{::keys [roles] :as request}]
     (let [required (some-> request (ring/get-match) :data ::roles)]
       (if (and (seq required) (not (set/subset? required roles)))
         {:status 403, :body "forbidden"}

--- a/doc/ring/transforming_middleware_chain.md
+++ b/doc/ring/transforming_middleware_chain.md
@@ -12,7 +12,7 @@ There is an extra option in ring-router (actually, in the underlying middleware-
   (fn [request]
     (handler (update request ::acc (fnil conj []) id))))
 
-(defn handler [{:keys [::acc]}]
+(defn handler [{::keys [acc]}]
   {:status 200, :body (conj acc :handler)})
 
 (def app

--- a/modules/reitit-core/src/reitit/coercion.cljc
+++ b/modules/reitit-core/src/reitit/coercion.cljc
@@ -70,7 +70,7 @@
   (-> request :muuntaja/request :format))
 
 ;; TODO: support faster key walking, walk/keywordize-keys is quite slow...
-(defn request-coercer [coercion type model {:keys [::extract-request-format ::parameter-coercion]
+(defn request-coercer [coercion type model {::keys [extract-request-format parameter-coercion]
                                             :or {extract-request-format extract-request-format-default
                                                  parameter-coercion default-parameter-coercion}}]
   (if coercion

--- a/modules/reitit-core/src/reitit/interceptor.cljc
+++ b/modules/reitit-core/src/reitit/interceptor.cljc
@@ -33,7 +33,7 @@
 
   #?(:clj  clojure.lang.Keyword
      :cljs cljs.core.Keyword)
-  (into-interceptor [this data {:keys [::registry] :as opts}]
+  (into-interceptor [this data {::keys [registry] :as opts}]
     (if-let [interceptor (if registry (registry this))]
       (into-interceptor interceptor data opts)
       (throw
@@ -108,7 +108,7 @@
    (chain interceptors nil nil))
   ([interceptors data]
    (chain interceptors data nil))
-  ([interceptors data {:keys [::transform] :or {transform identity} :as opts}]
+  ([interceptors data {::keys [transform] :or {transform identity} :as opts}]
    (let [transform (if (vector? transform) (apply comp (reverse transform)) transform)]
      (->> interceptors
           (keep #(into-interceptor % data opts))
@@ -119,7 +119,7 @@
 (defn compile-result
   ([route opts]
    (compile-result route opts nil))
-  ([[_ {:keys [interceptors handler] :as data}] {:keys [::queue] :as opts} _]
+  ([[_ {:keys [interceptors handler] :as data}] {::keys [queue] :as opts} _]
    (let [chain (chain (into (vec interceptors) [handler]) data opts)]
      (map->Endpoint
        {:interceptors chain

--- a/modules/reitit-core/src/reitit/middleware.cljc
+++ b/modules/reitit-core/src/reitit/middleware.cljc
@@ -17,7 +17,7 @@
 
   #?(:clj  clojure.lang.Keyword
      :cljs cljs.core.Keyword)
-  (into-middleware [this data {:keys [::registry] :as opts}]
+  (into-middleware [this data {::keys [registry] :as opts}]
     (if-let [middleware (if registry (registry this))]
       (into-middleware middleware data opts)
       (throw
@@ -83,7 +83,7 @@
              (if scope {:scope scope})))))
 
 (defn- expand-and-transform
-  [middleware data {:keys [::transform] :or {transform identity} :as opts}]
+  [middleware data {::keys [transform] :or {transform identity} :as opts}]
   (let [transform (if (vector? transform) (apply comp (reverse transform)) transform)]
     (->> middleware
          (keep #(into-middleware % data opts))

--- a/modules/reitit-core/src/reitit/spec.cljc
+++ b/modules/reitit-core/src/reitit/spec.cljc
@@ -123,7 +123,7 @@
                  (->Problem p nil d spec problems)))
              (keep identity) (seq) (vec))))
 
-(defn validate [routes {:keys [spec ::wrap] :or {spec ::default-data, wrap identity}}]
+(defn validate [routes {:keys [spec] ::keys [wrap] :or {spec ::default-data, wrap identity}}]
   (when-let [problems (validate-route-data routes wrap spec)]
     (exception/fail!
       ::invalid-route-data

--- a/modules/reitit-http/src/reitit/http.cljc
+++ b/modules/reitit-http/src/reitit/http.cljc
@@ -13,7 +13,7 @@
               (update acc method expand opts)
               acc)) data ring/http-methods)])
 
-(defn compile-result [[path data] {:keys [::default-options-handler] :as opts}]
+(defn compile-result [[path data] {::keys [default-options-handler] :as opts}]
   (let [[top childs] (ring/group-keys data)
         childs (cond-> childs
                        (and (not (:options childs)) (not (:handler top)) default-options-handler)

--- a/modules/reitit-interceptors/src/reitit/http/interceptors/dev.clj
+++ b/modules/reitit-interceptors/src/reitit/http/interceptors/dev.clj
@@ -24,7 +24,7 @@
       (update :request dissoc ::r/match ::r/router)))
 
 (defn- handle [name stage]
-  (fn [{:keys [::original ::previous] :as ctx}]
+  (fn [{::keys [previous] :as ctx}]
     (let [current (polish ctx)
           previous (polish previous)]
       (printer/print-doc (diff-doc stage name previous current) printer)

--- a/modules/reitit-middleware/src/reitit/ring/middleware/dev.clj
+++ b/modules/reitit-middleware/src/reitit/ring/middleware/dev.clj
@@ -18,13 +18,13 @@
 (defn polish [request]
   (dissoc request ::r/match ::r/router ::original ::previous))
 
-(defn printed-request [name {:keys [::original ::previous] :as request}]
+(defn printed-request [name {::keys [previous] :as request}]
   (printer/print-doc (diff-doc :request name (polish previous) (polish request)) printer)
   (-> request
       (update ::original (fnil identity request))
       (assoc ::previous request)))
 
-(defn printed-response [name {:keys [::original ::previous] :as response}]
+(defn printed-response [name {::keys [previous] :as response}]
   (printer/print-doc (diff-doc :response name (polish previous) (polish response)) printer)
   (-> response
       (update ::original (fnil identity response))

--- a/modules/reitit-pedestal/src/reitit/pedestal.clj
+++ b/modules/reitit-pedestal/src/reitit/pedestal.clj
@@ -49,7 +49,7 @@
     Executor
     (queue [_ interceptors]
       (->> interceptors
-           (map (fn [{:keys [::interceptor/handler] :as interceptor}]
+           (map (fn [{::interceptor/keys [handler] :as interceptor}]
                   (or handler interceptor)))
            (keep ->interceptor)))
     (enqueue [_ context interceptors]

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -28,7 +28,7 @@
               (update acc method expand opts)
               acc)) data http-methods)])
 
-(defn compile-result [[path data] {:keys [::default-options-handler] :as opts}]
+(defn compile-result [[path data] {::keys [default-options-handler] :as opts}]
   (let [[top childs] (group-keys data)
         childs (cond-> childs
                        (and (not (:options childs)) (not (:handler top)) default-options-handler)

--- a/modules/reitit-sieppari/src/reitit/interceptor/sieppari.clj
+++ b/modules/reitit-sieppari/src/reitit/interceptor/sieppari.clj
@@ -9,7 +9,7 @@
     (queue [_ interceptors]
       (queue/into-queue
         (map
-          (fn [{:keys [::interceptor/handler] :as interceptor}]
+          (fn [{::interceptor/keys [handler] :as interceptor}]
             (or handler interceptor))
           interceptors)))
     (execute [_ interceptors request]

--- a/modules/reitit-swagger/src/reitit/swagger.cljc
+++ b/modules/reitit-swagger/src/reitit/swagger.cljc
@@ -71,7 +71,7 @@
   "Create a ring handler to emit swagger spec. Collects all routes from router which have
   an intersecting `[:swagger :id]` and which are not marked with `:no-doc` route data."
   (fn create-swagger
-    ([{:keys [::r/router ::r/match :request-method]}]
+    ([{::r/keys [router match] :keys [request-method]}]
      (let [{:keys [id] :or {id ::default} :as swagger} (-> match :result request-method :data :swagger)
            ids (trie/into-set id)
            strip-top-level-keys #(dissoc % :id :info :host :basePath :definitions :securityDefinitions)

--- a/test/clj/reitit/http_test.clj
+++ b/test/clj/reitit/http_test.clj
@@ -11,7 +11,7 @@
 (defn interceptor [name]
   {:enter (fn [ctx] (update-in ctx [:request ::i] (fnil conj []) name))})
 
-(defn handler [{:keys [::i]}]
+(defn handler [{::keys [i]}]
   {:status 200 :body (conj i :ok)})
 
 (deftest http-router-test
@@ -89,7 +89,7 @@
           (is (= name (-> (r/match-by-name router name) :data :name))))))))
 
 (def enforce-roles-interceptor
-  {:enter (fn [{{:keys [::roles] :as request} :request :as ctx}]
+  {:enter (fn [{{::keys [roles] :as request} :request :as ctx}]
             (let [required (some-> request (http/get-match) :data ::roles)]
               (if (and (seq required) (not (set/intersection required roles)))
                 (-> ctx
@@ -280,7 +280,7 @@
   (let [interceptor (fn [name] {:name name
                                 :enter (fn [ctx]
                                          (update-in ctx [:request ::i] (fnil conj []) name))})
-        handler (fn [{:keys [::i]}] {:status 200 :body (conj i :ok)})
+        handler (fn [{::keys [i]}] {:status 200 :body (conj i :ok)})
         request {:uri "/api/avaruus" :request-method :get}
         create (fn [options]
                  (http/ring-handler
@@ -492,14 +492,14 @@
   (testing "1-arity"
     ((http/ring-handler
        (http/router [])
-       (fn [{:keys [::r/router]}]
+       (fn [{::r/keys [router]}]
          (is router))
        {:executor sieppari/executor})
      {}))
   (testing "3-arity"
     ((http/ring-handler
        (http/router [])
-       (fn [{:keys [::r/router]}]
+       (fn [{::r/keys [router]}]
          (is router))
        {:executor sieppari/executor})
      {} ::respond ::raise)))

--- a/test/cljc/reitit/ring_test.cljc
+++ b/test/cljc/reitit/ring_test.cljc
@@ -19,7 +19,7 @@
   (mw handler (keyword (str name "_" name2 "_" name3))))
 
 (defn handler
-  ([{:keys [::mw]}]
+  ([{::keys [mw]}]
    {:status 200 :body (conj mw :ok)})
   ([request respond _]
    (respond (handler request))))
@@ -119,7 +119,7 @@
           (is (= name (-> (r/match-by-name router name) :data :name))))))))
 
 (defn wrap-enforce-roles [handler]
-  (fn [{:keys [::roles] :as request}]
+  (fn [{::keys [roles] :as request}]
     (let [required (some-> request (ring/get-match) :data ::roles)]
       (if (and (seq required) (not (set/intersection required roles)))
         {:status 403, :body "forbidden"}
@@ -399,7 +399,7 @@
                                :wrap (fn [handler]
                                        (fn [request]
                                          (handler (update request ::mw (fnil conj []) name))))})
-        handler (fn [{:keys [::mw]}] {:status 200 :body (conj mw :ok)})
+        handler (fn [{::keys [mw]}] {:status 200 :body (conj mw :ok)})
         request {:uri "/api/avaruus" :request-method :get}
         create (fn [options]
                  (ring/ring-handler
@@ -583,13 +583,13 @@
   (testing "1-arity"
     ((ring/ring-handler
        (ring/router [])
-       (fn [{:keys [::r/router]}]
+       (fn [{::r/keys [router]}]
          (is router)))
      {}))
   (testing "3-arity"
     ((ring/ring-handler
        (ring/router [])
-       (fn [{:keys [::r/router]} _ _]
+       (fn [{::r/keys [router]} _ _]
          (is router)))
      {} ::respond ::raise)))
 


### PR DESCRIPTION
It's possible to put the :keys keyword in the namespace of the keys one likes to
destructure. With that one can use symbols in the vector again. One advantage of
having symbols is, that Cursive grays them out if not used. I found two
occurrences of unused destructured keys.