### PR TITLE
Update docs for controller and identity

### DIFF
--- a/doc/frontend/controllers.md
+++ b/doc/frontend/controllers.md
@@ -17,8 +17,8 @@ controller identity
 * `start` & `stop` functions, which are called with controller identity
 
 When you navigate to a route that has a controller, controller identity
-is first resolved by calling `identity` function, or by using `parameters`
-declaration, or if neither is set, the identity is `nil`. Next, the controller
+is first resolved by using `parameters` declaration, or by calling `identity` function,
+or if neither is set, the identity is `nil`. Next, the controller
 is initialized by calling `start` with the controller identity value.
 When you exit that route, `stop` is called with the last controller identity value.
 

--- a/doc/frontend/controllers.md
+++ b/doc/frontend/controllers.md
@@ -18,9 +18,9 @@ controller identity
 
 When you navigate to a route that has a controller, controller identity
 is first resolved by calling `identity` function, or by using `parameters`
-declaration, or if neither is set, the identity is `nil`. Next controller
-is initialized by calling `start` is called with the identity value.
-When you exit that route, `stop` is called with the return value of `params.`
+declaration, or if neither is set, the identity is `nil`. Next, the controller
+is initialized by calling `start` with the controller identity value.
+When you exit that route, `stop` is called with the last controller identity value.
 
 If you navigate to the same route with different match, identity gets
 resolved again. If the identity changes from the previous value, controller


### PR DESCRIPTION
Fixed typos in a sentence about `start`. Also updated the information about `stop` call, looks like it will be called with last controller identity value, not return value of params