### PR TITLE
Add ring session middleware

### DIFF
--- a/modules/reitit-middleware/src/reitit/ring/middleware/session.clj
+++ b/modules/reitit-middleware/src/reitit/ring/middleware/session.clj
@@ -1,10 +1,13 @@
 (ns reitit.ring.middleware.session
   (:require
+   [clojure.spec.alpha :as s]
    [ring.middleware.session :as session]
    [ring.middleware.session.memory :as memory]))
 
+(s/def ::spec (s/keys :opt-un [::session]))
+
 (def ^:private store
-  "The in-memory session store.
+  "The default shared in-memory session store.
 
   This is used when no `:session` key is provided to the middleware."
   (atom {}))
@@ -12,12 +15,19 @@
 (def session-middleware
   "Middleware for session.
 
-  Decodes the session from a request map into the `:session` value and updates the session store
-  based on the response's `:session` value.
+  Enter:
+  Add the `:session` key into the request map based on the `:cookies`
+  in the request map.
+
+  Exit:
+  When `:session` key presents in the response map, update the session
+  store with its value. Then remove `:session` from the response map.
 
   | key          | description |
   | -------------|-------------|
   | `:session`   | `ring.middleware.session.store/SessionStore` instance. Use `ring.middleware.session.memory/MemoryStore` by default."
   {:name    :session
-   :compile (fn [{:keys [session] :or {session {:store (memory/memory-store store)}}} _]
+   :spec    ::spec
+   :compile (fn [{:keys [session]
+                 :or   {session {:store (memory/memory-store store)}}} _]
               {:wrap #(session/wrap-session % session)})})

--- a/modules/reitit-middleware/src/reitit/ring/middleware/session.clj
+++ b/modules/reitit-middleware/src/reitit/ring/middleware/session.clj
@@ -1,0 +1,23 @@
+(ns reitit.ring.middleware.session
+  (:require
+   [ring.middleware.session :as session]
+   [ring.middleware.session.memory :as memory]))
+
+(def ^:private store
+  "The in-memory session store.
+
+  This is used when no `:session` key is provided to the middleware."
+  (atom {}))
+
+(def session-middleware
+  "Middleware for session.
+
+  Decodes the session from a request map into the `:session` value and updates the session store
+  based on the response's `:session` value.
+
+  | key          | description |
+  | -------------|-------------|
+  | `:session`   | `ring.middleware.session.store/SessionStore` instance. Use `ring.middleware.session.memory/MemoryStore` by default."
+  {:name    :session
+   :compile (fn [{:keys [session] :or {session {:store (memory/memory-store store)}}} _]
+              {:wrap #(session/wrap-session % session)})})

--- a/test/clj/reitit/ring/middleware/session_test.clj
+++ b/test/clj/reitit/ring/middleware/session_test.clj
@@ -1,0 +1,60 @@
+(ns reitit.ring.middleware.session-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [reitit.ring.middleware.session :as session]
+            [ring.middleware.session.memory :as memory]
+            [reitit.ring :as ring]))
+
+(defn get-session-id
+  "Parse the session-id out of response headers."
+  [request]
+  (let [pattern  #"ring-session=([-\w]+);Path=/;HttpOnly"
+        parse-fn (partial re-find pattern)]
+    (-> request
+        (get-in [:headers "Set-Cookie"])
+        first
+        parse-fn
+        second)))
+
+(defn handler
+  "The handler that increments the counter."
+  [{session :session}]
+  (let [counter (inc (:counter session 0))]
+    {:status  200
+     :body    {:counter counter}
+     :session {:counter counter}}))
+
+(deftest session-test
+  (let [store           (atom {})
+        app             (ring/ring-handler
+                         (ring/router
+                          ["/api"
+                           {:session    {:store (memory/memory-store store)}
+                            :middleware [session/session-middleware]}
+                           ["/ping" handler]
+                           ["/pong" handler]]))
+        first-response  (app {:request-method :get
+                              :uri            "/api/ping"})
+        session-id      (get-session-id first-response)
+        second-response (app {:request-method :get
+                              :uri            "/api/pong"
+                              :cookies        {"ring-session" {:value session-id}}})]
+    (is (= (count @store)
+           1))
+    (is (-> @store first second)
+        {:counter 2})))
+
+(deftest default-session-test
+  (let [app             (ring/ring-handler
+                         (ring/router
+                          ["/api"
+                           {:middleware [session/session-middleware]}
+                           ["/ping" handler]
+                           ["/pong" handler]]))
+        first-response  (app {:request-method :get
+                              :uri            "/api/ping"})
+        session-id      (get-session-id first-response)
+        second-response (app {:request-method :get
+                              :uri            "/api/pong"
+                              :cookies        {"ring-session" {:value session-id}}})]
+    (is (= (inc (get-in first-response [:body :counter]))
+           (get-in second-response [:body :counter])))))


### PR DESCRIPTION
This PR addresses issue #205 

Problem: 
> wrap-session instantiates the default memory store per instance. This means that every route will have their own memory-store. This is a surprising default and should be resolved.

Solution: The `reitit.ring.middleware.session` ns shares one single store instance when the session store isn't specified from the user.

Please let me know if there's anything that I can improve for this PR. Thank you!