### PR TITLE
Validate ring middleware

### DIFF
--- a/modules/reitit-ring/src/reitit/ring/spec.cljc
+++ b/modules/reitit-ring/src/reitit/ring/spec.cljc
@@ -8,7 +8,7 @@
 ;; Specs
 ;;
 
-(s/def ::middleware (s/coll-of #(satisfies? middleware/IntoMiddleware %)))
+(s/def ::middleware (s/coll-of #(satisfies? middleware/IntoMiddleware %) :kind vector?))
 (s/def ::get map?)
 (s/def ::head map?)
 (s/def ::post map?)

--- a/test/cljc/reitit/ring_spec_test.cljc
+++ b/test/cljc/reitit/ring_spec_test.cljc
@@ -81,7 +81,7 @@
   (testing "middleware cannot be a list"
     (is (thrown-with-msg?
          ExceptionInfo
-         #":reitit.ring.spec/invalid-specs"
+         #"Invalid route data"
          (ring/router
           ["/api" {:handler    identity
                    :middleware '()}]

--- a/test/cljc/reitit/ring_spec_test.cljc
+++ b/test/cljc/reitit/ring_spec_test.cljc
@@ -77,7 +77,15 @@
              :data {:middleware [{:spec (s/keys :opt-un [::roles])
                                   :wrap (fn [handler]
                                           (fn [request]
-                                            (handler request)))}]}})))))
+                                              (handler request)))}]}}))))
+  (testing "middleware cannot be a list"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #":reitit.ring.spec/invalid-specs"
+         (ring/router
+          ["/api" {:handler    identity
+                   :middleware '()}]
+          {:validate rrs/validate})))))
 
 (deftest coercion-spec-test
   (is (r/router?


### PR DESCRIPTION
This PR addresses issue #296 

Problem: The order of middleware chain reversed when middleware is a list.

Solution: Validate the middleware to be vectors only.