### PR TITLE
Add an example project with Integrant

### DIFF
--- a/examples/ring-integrant/.gitignore
+++ b/examples/ring-integrant/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/examples/ring-integrant/README.md
+++ b/examples/ring-integrant/README.md
@@ -1,0 +1,18 @@
+# Ring Reitit example
+
+A Sample project with ring and reitit.
+
+## Usage
+
+```clj
+> lein repl
+(start)
+```
+
+Go with browser to:
+
+* http://localhost:3000/ping
+
+## License
+
+Copyright © 2017-2018 Metosin Oy

--- a/examples/ring-integrant/README.md
+++ b/examples/ring-integrant/README.md
@@ -4,9 +4,17 @@ A Sample project with ring and reitit.
 
 ## Usage
 
-```clj
-> lein repl
-(start)
+Run Ring server in command line:
+
+```bash
+lein run
+```
+
+Run Ring server in the REPL
+
+```bash
+lein repl
+> (go)
 ```
 
 Go with browser to:

--- a/examples/ring-integrant/dev/user.clj
+++ b/examples/ring-integrant/dev/user.clj
@@ -1,0 +1,15 @@
+(ns user
+  (:require
+   [integrant.repl :as ig-repl]
+   [example.server]))
+
+(ig-repl/set-prep! (constantly example.server/system-config))
+
+(def go ig-repl/go)
+(def halt ig-repl/halt)
+(def reset ig-repl/reset)
+
+(comment
+  (go)
+  (reset)
+  (halt))

--- a/examples/ring-integrant/project.clj
+++ b/examples/ring-integrant/project.clj
@@ -1,0 +1,7 @@
+(defproject ring-integrant-example "0.1.0-SNAPSHOT"
+  :description "Reitit Ring App with Swagger"
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [ring/ring-jetty-adapter "1.7.1"]
+                 [metosin/reitit "0.3.10"]
+                 [integrant "0.7.0"]]
+  :repl-options {:init-ns example.server})

--- a/examples/ring-integrant/project.clj
+++ b/examples/ring-integrant/project.clj
@@ -1,7 +1,10 @@
 (defproject ring-integrant-example "0.1.0-SNAPSHOT"
-  :description "Reitit Ring App with Swagger"
+  :description "Reitit Ring App with Integrant"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [ring/ring-jetty-adapter "1.7.1"]
                  [metosin/reitit "0.3.10"]
                  [integrant "0.7.0"]]
-  :repl-options {:init-ns example.server})
+  :main example.server
+  :repl-options {:init-ns user}
+  :profiles {:dev {:dependencies [[integrant/repl "0.3.1"]]
+                   :source-paths ["dev"]}})

--- a/examples/ring-integrant/src/example/server.clj
+++ b/examples/ring-integrant/src/example/server.clj
@@ -4,8 +4,6 @@
    [ring.adapter.jetty :as jetty]
    [integrant.core :as ig]))
 
-(defonce server (atom nil))
-
 (def system-config
   {:example/jetty   {:port    3000
                      :join?   false
@@ -24,12 +22,5 @@
    (ring/router
     ["/ping" {:get {:handler (fn [_] {:status 200 :body "pong!"})}}])))
 
-(defn start []
-  (reset! server (ig/init system-config)))
-
-(defn stop []
-  (swap! server ig/halt!))
-
-(comment
-  (start)
-  (stop))
+(defn -main []
+  (ig/init system-config))

--- a/examples/ring-integrant/src/example/server.clj
+++ b/examples/ring-integrant/src/example/server.clj
@@ -1,0 +1,35 @@
+(ns example.server
+  (:require
+   [reitit.ring :as ring]
+   [ring.adapter.jetty :as jetty]
+   [integrant.core :as ig]))
+
+(defonce server (atom nil))
+
+(def system-config
+  {:example/jetty   {:port    3000
+                     :join?   false
+                     :handler (ig/ref :example/handler)}
+   :example/handler {}})
+
+(defmethod ig/init-key :example/jetty [_ {:keys [port join? handler]}]
+  (println "server running in port" port)
+  (jetty/run-jetty handler {:port port :join? join?}))
+
+(defmethod ig/halt-key! :example/jetty [_ server]
+  (.stop server))
+
+(defmethod ig/init-key :example/handler [_ _]
+  (ring/ring-handler
+   (ring/router
+    ["/ping" {:get {:handler (fn [_] {:status 200 :body "pong!"})}}])))
+
+(defn start []
+  (reset! server (ig/init system-config)))
+
+(defn stop []
+  (swap! server ig/halt!))
+
+(comment
+  (start)
+  (stop))


### PR DESCRIPTION
This PR addresses #265 

Feedbacks are welcome.
Currently, the project is minimal. The system only contains two keys: `:example/jetty` and `:example/handler`. I can certainly add more features.