### PR TITLE
Publish intermediate paths by default

### DIFF
--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -334,7 +334,6 @@
 ;; Creating Routers
 ;;
 
-
 (defn ^:no-doc default-router-options []
   {:lookup (fn lookup [[_ {:keys [name]}] _] (if name #{name}))
    :expand expand

--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -334,13 +334,15 @@
 ;; Creating Routers
 ;;
 
+
 (defn ^:no-doc default-router-options []
   {:lookup (fn lookup [[_ {:keys [name]}] _] (if name #{name}))
    :expand expand
    :coerce (fn coerce [route _] route)
    :compile (fn compile [[_ {:keys [handler]}] _] handler)
    :exception exception/exception
-   :conflicts (fn throw! [conflicts] (exception/fail! :path-conflicts conflicts))})
+   :conflicts (fn throw! [conflicts] (exception/fail! :path-conflicts conflicts))
+   :endpoint  impl/leaf-endpoint})
 
 (defn router
   "Create a [[Router]] from raw route data and optionally an options map.
@@ -360,7 +362,10 @@
   | `:validate`  | Function of `routes opts => ()` to validate route (data) via side-effects
   | `:conflicts` | Function of `{route #{route}} => ()` to handle conflicting routes
   | `:exception` | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
-  | `:router`    | Function of `routes opts => router` to override the actual router implementation"
+  | `:router`    | Function of `routes opts => router` to override the actual router implementation
+  | `:endpoint`  | Function of `prev-path path expanded-data data children => {:endpoint :inherit}`.
+  |              | Used to transform data for this endpoint and data inherited to child routes.
+  |              | Return falsy or `{:endpoint nil}` to skip path as endpoint and pass data to children."
   ([raw-routes]
    (router raw-routes {}))
   ([raw-routes opts]

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -265,6 +265,61 @@
     {:endpoint data
      :inherit  {}}))
 
+(defn dissoc-in
+  "Dissociates an entry from a nested associative structure returning a new
+  nested structure. `keys` is a sequence of keys. Any empty maps that result
+  will not be present in the new structure."
+  [m [k & ks]]
+  (if ks
+    (if-let [nextmap (get m k)]
+      (let [newmap (dissoc-in nextmap ks)]
+        (if (seq newmap)
+          (assoc m k newmap)
+          (dissoc m k)))
+      m)
+    (dissoc m k)))
+
+(defn transform-inherited-data
+  [transform-configs data]
+  (let [short-hands {:consume #(dissoc-in %1 %2)
+                     :inherit (fn [d _] d)}]
+    (reduce
+      (fn [acc {:keys [kss transform]}]
+        (let [transform (or (get short-hands transform)
+                            transform)]
+          (reduce (fn [{:keys [inherit endpoint]} ks]
+                    (if (get-in inherit ks)
+                      {:inherit (transform inherit ks) :endpoint data}
+                      {:inherit inherit :endpoint endpoint}))
+                  acc
+                  kss)))
+      {:endpoint nil :inherit data}
+      transform-configs)))
+
+(defn mk-intermediate-endpoint-transform
+  "Make function that returns map for valid endpoints, which are either a leaf path in
+  the route tree, or have route data for one or more of nested key sequences.
+  The returned map will contain data for the current endpoint under `:endpoint` and data to be
+  inherited for children under `:inherit`.
+
+  Provided arg should be a vector of maps with :kss, a seq of seq of keys, and :transform. Expanded route data
+  will be queried with each of the key sequences. If data exists in the key sequence, the provided `:transform` function
+  is called with `(transform data ks)`, so that the result is to be passed to children.
+  Query is repeated for each seq of seq with the same transform, moving on to the next transform.
+  All transforms are performed before passing data to children.
+
+  If none of the key seqs match, then falsy is returned to indicate that the path should
+  not be used as an endpoint.
+
+  Optionally, `:transform` may be specified with keywords `:consume` as short-hand for removing the matching data,
+  or `:inherit` for passing the data as-is to children."
+  [transform-configs]
+  (fn [prev-path path meta data childs]
+    (or (leaf-endpoint prev-path path meta data childs)
+        (and (map? data)
+             (seq childs)
+             (transform-inherited-data transform-configs data)))))
+
 (defmacro goog-extend [type base-type ctor & methods]
   `(do
      (def ~type (fn ~@ctor))

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -53,15 +53,15 @@
                                             (sequential? (first maybe-arg)))
                                        (nil? maybe-arg))
                                  [{} args]
-                                 [maybe-arg (rest args)])]
-             (let [d (endpoint pacc path macc data childs)
-                   data-for-endpoint (when (:endpoint d) (into macc (expand (:endpoint d) opts)))
-                   data-for-children (or (:inherit d) data)
-                   macc (into macc (expand data-for-children opts))]
+                                 [maybe-arg (rest args)])
+                 d (endpoint pacc path macc data childs)
+                 data-for-endpoint (when (:endpoint d) (into macc (expand (:endpoint d) opts)))
+                 data-for-children (or (:inherit d) data)
+                 macc (into macc (expand data-for-children opts))]
                (-> (when data-for-endpoint [[(str pacc path) data-for-endpoint]])
                    (concat (when (seq childs) (-> (str pacc path)
                                                   (walk-many macc (keep identity childs))
-                                                  (seq))))))))))]
+                                                  (seq)))))))))]
     (walk-one path (mapv identity data) raw-routes)))
 
 (defn map-data [f routes]

--- a/modules/reitit-frontend/src/reitit/frontend.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend.cljs
@@ -2,7 +2,8 @@
   (:require [clojure.set :as set]
             [reitit.coercion :as coercion]
             [reitit.coercion :as rc]
-            [reitit.core :as r])
+            [reitit.core :as r]
+            [reitit.impl :as impl])
   (:import goog.Uri
            goog.Uri.QueryData))
 
@@ -45,13 +46,17 @@
   ([router name path-params]
    (r/match-by-name router name path-params)))
 
+(def frontend-endpoint (impl/mk-intermediate-endpoint-transform [{:kss       [[:name]]
+                                                                  :transform :consume}]))
+
 (defn router
   "Create a `reitit.core.router` from raw route data and optionally an options map.
   Enables request coercion. See [[reitit.core/router]] for details on options."
   ([raw-routes]
    (router raw-routes {}))
   ([raw-routes opts]
-   (r/router raw-routes (merge {:compile rc/compile-request-coercers} opts))))
+   (r/router raw-routes (merge {:compile rc/compile-request-coercers
+                                :endpoint frontend-endpoint} opts))))
 
 (defn match-by-name!
   "Logs problems using console.warn"

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -65,6 +65,11 @@
       ([request respond _]
        (respond (handle request))))))
 
+(def ring-endpoint (impl/mk-intermediate-endpoint-transform [{:kss (for [method http-methods] [method :handler])
+                                                              :transform :inherit}
+                                                             {:kss       [[:name]]
+                                                              :transform :consume}]))
+
 ;;
 ;; public api
 ;;
@@ -93,7 +98,8 @@
   ([data opts]
    (let [opts (merge {:coerce coerce-handler
                       :compile compile-result
-                      ::default-options-handler default-options-handler} opts)]
+                      ::default-options-handler default-options-handler
+                      :endpoint ring-endpoint} opts)]
      (r/router data opts))))
 
 (defn routes


### PR DESCRIPTION
Currently, only leaf routes can be used as endpoints. This causes unexpected behaviour, for example, when intermediate paths are defined with a handler, but they are not published. This seems to be confusing, especially when starting out with Reitit. 

This PR changes the default so that intermediate paths are published as endpoints, if they have certain data (e.g., a `:handler` for a backend route) that is typical for intended endpoints. 

Changes in this PR allow customizing the endpoint resolution with a `:endpoint?` predicate, and provide default predicates for the frontend and Ring routing. 

See https://github.com/metosin/reitit/issues/175

Note that checking leaf routes for any data is left for later implementation. 