### PR TITLE
Workaround for CircleCI problems

### DIFF
--- a/.circleci/config.orig.yml
+++ b/.circleci/config.orig.yml
@@ -1,0 +1,130 @@
+version: 2.1
+
+jobs:
+  test-clj:
+    working_directory: ~/test
+    parameters:
+      image-name:
+        type: string
+    docker:
+      - image: << parameters.image-name >>
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - 'v1-clj-{{ checksum "project.clj" }}'
+            - 'v1-clj-'
+            - 'v1-test-'
+      - run:
+          name: Install modules
+          command: ./scripts/lein-modules install
+      - run:
+          name: Run tests
+          command: ./scripts/test.sh clj
+      - run:
+          name: Install curl if missing
+          command: apt update && apt install -y curl
+      - run:
+          name: Verify cljdoc.edn
+          command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
+      - store_test_results:
+          # path must be a directory under which there a subdirectories that
+          # contain the JUnit XML files.
+          path: ~/test/target/results
+#      - run:
+#          name: Run coverage
+#          command: ./scripts/submit-to-coveralls.sh clj
+      - save_cache:
+          key: 'v1-clj-{{ checksum "project.clj" }}'
+          paths:
+            - ~/.m2
+            - ~/.cljs/.aot_cache
+
+  test-cljs:
+    working_directory: ~/test
+    docker:
+      - image: circleci/clojure:lein-2.8.1-node-browsers
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - 'v1-cljs-{{ checksum "project.clj" }}-{{ checksum "package.json" }}'
+            - 'v1-cljs-'
+      - run:
+          name: Install npm dependencies
+          command: npm install
+      - run:
+          name: Install modules
+          command: ./scripts/lein-modules install
+      - run:
+          name: Run tests
+          command: ./scripts/test.sh cljs
+      - store_test_results:
+          path: ~/test/target/results
+      - save_cache:
+          key: 'v1-cljs-{{ checksum "project.clj" }}-{{ checksum "package.json" }}'
+          paths:
+            - ~/.m2
+            - ~/test/node_modules
+
+  build-docs:
+    working_directory: ~/build
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - run: rm package.json package-lock.json
+      - restore_cache:
+          keys:
+            - 'v1-gitbook-{{ checksum "book.json" }}'
+            - 'v1-gitbook-'
+      - run:
+          name: "Install GitBook"
+          command: npm install gitbook-cli && ./node_modules/.bin/gitbook install
+      - run:
+          name: "Clone gh-pages"
+          command: git clone --branch gh-pages git@github.com:metosin/reitit.git ~/gh-pages
+      - run:
+          name: Build the documentation
+          command: |
+            ./node_modules/.bin/gitbook build
+            cp -r _book/* ~/gh-pages/
+      - add_ssh_keys:
+          fingerprints:
+            - "2d:eb:be:af:53:33:36:01:40:61:81:9d:76:84:8e:83"
+      - deploy:
+          name: Upload the documentation
+          command: |
+            cd ~/gh-pages
+            git config user.name  "Automatic build"
+            git config user.email "noreply@metosin.fi"
+            git add -A
+            git commit -m "Build book from commit $CIRCLE_SHA1 [skip ci]"
+            git push
+      - save_cache:
+          key: 'v1-gitbook-{{ checksum "book.json" }}'
+          paths:
+            - node_modules
+
+workflows:
+  version: 2
+  test-and-build-docs:
+    jobs:
+      - test-clj:
+          name: jdk8
+          image-name: clojure:openjdk-8-lein-2.9.1
+      - test-clj:
+          name: jdk11
+          image-name: clojure:openjdk-11-lein-2.9.1
+      - test-clj:
+          name: jdk13
+          image-name: clojure:openjdk-13-lein-2.9.1
+      - test-clj:
+          name: jdk14
+          image-name: clojure:openjdk-14-lein-2.9.1
+      - test-cljs
+      - build-docs:
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,12 +111,16 @@ workflows:
   test-and-build-docs:
     jobs:
       - test-clj:
+          name: jdk8
           image-name: clojure:openjdk-8-lein-2.9.1
       - test-clj:
+          name: jdk11
           image-name: clojure:openjdk-11-lein-2.9.1
       - test-clj:
+          name: jdk13
           image-name: clojure:openjdk-13-lein-2.9.1
       - test-clj:
+          name: jdk14
           image-name: clojure:openjdk-14-lein-2.9.1
       - test-cljs
       - build-docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,130 +1,333 @@
-version: 2.1
-
+version: 2
 jobs:
-  test-clj:
+  jdk8:
     working_directory: ~/test
-    parameters:
-      image-name:
-        type: string
     docker:
-      - image: << parameters.image-name >>
+    - image: clojure:openjdk-8-lein-2.9.1
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - 'v1-clj-{{ checksum "project.clj" }}'
-            - 'v1-clj-'
-            - 'v1-test-'
-      - run:
-          name: Install modules
-          command: ./scripts/lein-modules install
-      - run:
-          name: Run tests
-          command: ./scripts/test.sh clj
-      - run:
-          name: Install curl if missing
-          command: apt update && apt install -y curl
-      - run:
-          name: Verify cljdoc.edn
-          command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
-      - store_test_results:
-          # path must be a directory under which there a subdirectories that
-          # contain the JUnit XML files.
-          path: ~/test/target/results
-#      - run:
-#          name: Run coverage
-#          command: ./scripts/submit-to-coveralls.sh clj
-      - save_cache:
-          key: 'v1-clj-{{ checksum "project.clj" }}'
-          paths:
-            - ~/.m2
-            - ~/.cljs/.aot_cache
-
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-clj-{{ checksum "project.clj" }}
+        - v1-clj-
+        - v1-test-
+    - run:
+        name: Install modules
+        command: ./scripts/lein-modules install
+    - run:
+        name: Run tests
+        command: ./scripts/test.sh clj
+    - run:
+        name: Install curl if missing
+        command: apt update && apt install -y curl
+    - run:
+        name: Verify cljdoc.edn
+        command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
+    - store_test_results:
+        path: ~/test/target/results
+    - save_cache:
+        key: v1-clj-{{ checksum "project.clj" }}
+        paths:
+        - ~/.m2
+        - ~/.cljs/.aot_cache
+  jdk11:
+    working_directory: ~/test
+    docker:
+    - image: clojure:openjdk-11-lein-2.9.1
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-clj-{{ checksum "project.clj" }}
+        - v1-clj-
+        - v1-test-
+    - run:
+        name: Install modules
+        command: ./scripts/lein-modules install
+    - run:
+        name: Run tests
+        command: ./scripts/test.sh clj
+    - run:
+        name: Install curl if missing
+        command: apt update && apt install -y curl
+    - run:
+        name: Verify cljdoc.edn
+        command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
+    - store_test_results:
+        path: ~/test/target/results
+    - save_cache:
+        key: v1-clj-{{ checksum "project.clj" }}
+        paths:
+        - ~/.m2
+        - ~/.cljs/.aot_cache
+  jdk13:
+    working_directory: ~/test
+    docker:
+    - image: clojure:openjdk-13-lein-2.9.1
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-clj-{{ checksum "project.clj" }}
+        - v1-clj-
+        - v1-test-
+    - run:
+        name: Install modules
+        command: ./scripts/lein-modules install
+    - run:
+        name: Run tests
+        command: ./scripts/test.sh clj
+    - run:
+        name: Install curl if missing
+        command: apt update && apt install -y curl
+    - run:
+        name: Verify cljdoc.edn
+        command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
+    - store_test_results:
+        path: ~/test/target/results
+    - save_cache:
+        key: v1-clj-{{ checksum "project.clj" }}
+        paths:
+        - ~/.m2
+        - ~/.cljs/.aot_cache
+  jdk14:
+    working_directory: ~/test
+    docker:
+    - image: clojure:openjdk-14-lein-2.9.1
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-clj-{{ checksum "project.clj" }}
+        - v1-clj-
+        - v1-test-
+    - run:
+        name: Install modules
+        command: ./scripts/lein-modules install
+    - run:
+        name: Run tests
+        command: ./scripts/test.sh clj
+    - run:
+        name: Install curl if missing
+        command: apt update && apt install -y curl
+    - run:
+        name: Verify cljdoc.edn
+        command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
+    - store_test_results:
+        path: ~/test/target/results
+    - save_cache:
+        key: v1-clj-{{ checksum "project.clj" }}
+        paths:
+        - ~/.m2
+        - ~/.cljs/.aot_cache
   test-cljs:
     working_directory: ~/test
     docker:
-      - image: circleci/clojure:lein-2.8.1-node-browsers
+    - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - 'v1-cljs-{{ checksum "project.clj" }}-{{ checksum "package.json" }}'
-            - 'v1-cljs-'
-      - run:
-          name: Install npm dependencies
-          command: npm install
-      - run:
-          name: Install modules
-          command: ./scripts/lein-modules install
-      - run:
-          name: Run tests
-          command: ./scripts/test.sh cljs
-      - store_test_results:
-          path: ~/test/target/results
-      - save_cache:
-          key: 'v1-cljs-{{ checksum "project.clj" }}-{{ checksum "package.json" }}'
-          paths:
-            - ~/.m2
-            - ~/test/node_modules
-
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-cljs-{{ checksum "project.clj" }}-{{ checksum "package.json" }}
+        - v1-cljs-
+    - run:
+        name: Install npm dependencies
+        command: npm install
+    - run:
+        name: Install modules
+        command: ./scripts/lein-modules install
+    - run:
+        name: Run tests
+        command: ./scripts/test.sh cljs
+    - store_test_results:
+        path: ~/test/target/results
+    - save_cache:
+        key: v1-cljs-{{ checksum "project.clj" }}-{{ checksum "package.json" }}
+        paths:
+        - ~/.m2
+        - ~/test/node_modules
   build-docs:
     working_directory: ~/build
     docker:
-      - image: circleci/node:latest
+    - image: circleci/node:latest
     steps:
-      - checkout
-      - run: rm package.json package-lock.json
-      - restore_cache:
-          keys:
-            - 'v1-gitbook-{{ checksum "book.json" }}'
-            - 'v1-gitbook-'
-      - run:
-          name: "Install GitBook"
-          command: npm install gitbook-cli && ./node_modules/.bin/gitbook install
-      - run:
-          name: "Clone gh-pages"
-          command: git clone --branch gh-pages git@github.com:metosin/reitit.git ~/gh-pages
-      - run:
-          name: Build the documentation
-          command: |
-            ./node_modules/.bin/gitbook build
-            cp -r _book/* ~/gh-pages/
-      - add_ssh_keys:
-          fingerprints:
-            - "2d:eb:be:af:53:33:36:01:40:61:81:9d:76:84:8e:83"
-      - deploy:
-          name: Upload the documentation
-          command: |
-            cd ~/gh-pages
-            git config user.name  "Automatic build"
-            git config user.email "noreply@metosin.fi"
-            git add -A
-            git commit -m "Build book from commit $CIRCLE_SHA1 [skip ci]"
-            git push
-      - save_cache:
-          key: 'v1-gitbook-{{ checksum "book.json" }}'
-          paths:
-            - node_modules
-
+    - checkout
+    - run:
+        command: rm package.json package-lock.json
+    - restore_cache:
+        keys:
+        - v1-gitbook-{{ checksum "book.json" }}
+        - v1-gitbook-
+    - run:
+        name: Install GitBook
+        command: npm install gitbook-cli && ./node_modules/.bin/gitbook install
+    - run:
+        name: Clone gh-pages
+        command: git clone --branch gh-pages git@github.com:metosin/reitit.git ~/gh-pages
+    - run:
+        name: Build the documentation
+        command: |
+          ./node_modules/.bin/gitbook build
+          cp -r _book/* ~/gh-pages/
+    - add_ssh_keys:
+        fingerprints:
+        - 2d:eb:be:af:53:33:36:01:40:61:81:9d:76:84:8e:83
+    - deploy:
+        name: Upload the documentation
+        command: |
+          cd ~/gh-pages
+          git config user.name  "Automatic build"
+          git config user.email "noreply@metosin.fi"
+          git add -A
+          git commit -m "Build book from commit $CIRCLE_SHA1 [skip ci]"
+          git push
+    - save_cache:
+        key: v1-gitbook-{{ checksum "book.json" }}
+        paths:
+        - node_modules
 workflows:
   version: 2
   test-and-build-docs:
     jobs:
-      - test-clj:
-          name: jdk8
-          image-name: clojure:openjdk-8-lein-2.9.1
-      - test-clj:
-          name: jdk11
-          image-name: clojure:openjdk-11-lein-2.9.1
-      - test-clj:
-          name: jdk13
-          image-name: clojure:openjdk-13-lein-2.9.1
-      - test-clj:
-          name: jdk14
-          image-name: clojure:openjdk-14-lein-2.9.1
-      - test-cljs
-      - build-docs:
-          filters:
-            branches:
-              only:
-                - master
+    - jdk8
+    - jdk11
+    - jdk13
+    - jdk14
+    - test-cljs
+    - build-docs:
+        filters:
+          branches:
+            only:
+            - master
+
+# Original config.yml file:
+# version: 2.1
+# 
+# jobs:
+#   test-clj:
+#     working_directory: ~/test
+#     parameters:
+#       image-name:
+#         type: string
+#     docker:
+#       - image: << parameters.image-name >>
+#     steps:
+#       - checkout
+#       - restore_cache:
+#           keys:
+#             - 'v1-clj-{{ checksum \"project.clj\" }}'
+#             - 'v1-clj-'
+#             - 'v1-test-'
+#       - run:
+#           name: Install modules
+#           command: ./scripts/lein-modules install
+#       - run:
+#           name: Run tests
+#           command: ./scripts/test.sh clj
+#       - run:
+#           name: Install curl if missing
+#           command: apt update && apt install -y curl
+#       - run:
+#           name: Verify cljdoc.edn
+#           command: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
+#       - store_test_results:
+#           # path must be a directory under which there a subdirectories that
+#           # contain the JUnit XML files.
+#           path: ~/test/target/results
+# #      - run:
+# #          name: Run coverage
+# #          command: ./scripts/submit-to-coveralls.sh clj
+#       - save_cache:
+#           key: 'v1-clj-{{ checksum \"project.clj\" }}'
+#           paths:
+#             - ~/.m2
+#             - ~/.cljs/.aot_cache
+# 
+#   test-cljs:
+#     working_directory: ~/test
+#     docker:
+#       - image: circleci/clojure:lein-2.8.1-node-browsers
+#     steps:
+#       - checkout
+#       - restore_cache:
+#           keys:
+#             - 'v1-cljs-{{ checksum \"project.clj\" }}-{{ checksum \"package.json\" }}'
+#             - 'v1-cljs-'
+#       - run:
+#           name: Install npm dependencies
+#           command: npm install
+#       - run:
+#           name: Install modules
+#           command: ./scripts/lein-modules install
+#       - run:
+#           name: Run tests
+#           command: ./scripts/test.sh cljs
+#       - store_test_results:
+#           path: ~/test/target/results
+#       - save_cache:
+#           key: 'v1-cljs-{{ checksum \"project.clj\" }}-{{ checksum \"package.json\" }}'
+#           paths:
+#             - ~/.m2
+#             - ~/test/node_modules
+# 
+#   build-docs:
+#     working_directory: ~/build
+#     docker:
+#       - image: circleci/node:latest
+#     steps:
+#       - checkout
+#       - run: rm package.json package-lock.json
+#       - restore_cache:
+#           keys:
+#             - 'v1-gitbook-{{ checksum \"book.json\" }}'
+#             - 'v1-gitbook-'
+#       - run:
+#           name: \"Install GitBook\"
+#           command: npm install gitbook-cli && ./node_modules/.bin/gitbook install
+#       - run:
+#           name: \"Clone gh-pages\"
+#           command: git clone --branch gh-pages git@github.com:metosin/reitit.git ~/gh-pages
+#       - run:
+#           name: Build the documentation
+#           command: |
+#             ./node_modules/.bin/gitbook build
+#             cp -r _book/* ~/gh-pages/
+#       - add_ssh_keys:
+#           fingerprints:
+#             - \"2d:eb:be:af:53:33:36:01:40:61:81:9d:76:84:8e:83\"
+#       - deploy:
+#           name: Upload the documentation
+#           command: |
+#             cd ~/gh-pages
+#             git config user.name  \"Automatic build\"
+#             git config user.email \"noreply@metosin.fi\"
+#             git add -A
+#             git commit -m \"Build book from commit $CIRCLE_SHA1 [skip ci]\"
+#             git push
+#       - save_cache:
+#           key: 'v1-gitbook-{{ checksum \"book.json\" }}'
+#           paths:
+#             - node_modules
+# 
+# workflows:
+#   version: 2
+#   test-and-build-docs:
+#     jobs:
+#       - test-clj:
+#           name: jdk8
+#           image-name: clojure:openjdk-8-lein-2.9.1
+#       - test-clj:
+#           name: jdk11
+#           image-name: clojure:openjdk-11-lein-2.9.1
+#       - test-clj:
+#           name: jdk13
+#           image-name: clojure:openjdk-13-lein-2.9.1
+#       - test-clj:
+#           name: jdk14
+#           image-name: clojure:openjdk-14-lein-2.9.1
+#       - test-cljs
+#       - build-docs:
+#           filters:
+#             branches:
+#               only:
+#                 - master


### PR DESCRIPTION
For some reason the CircleCI config from #327 do not work in master. I wonder if it's somehow related to the fact that `build-docs` is enabled for master but not for other branches. See e.g. [this workflow run](https://circleci.com/workflow-run/67522e3a-8ae6-4791-821a-88f804b1d745) for commit 54dc6e3dabc10a264c0a7d2a62417fe8d4ff7f6d.

I couldn't find anything from Circle's docs. As a workaround, I preprocessed the config manually with the `circleci` command-line tool:

```shell
cp .circleci/config.yml .circleci/config.orig.yml
circleci config process .circleci/config.orig.yml > .circleci/config.yml
```

cc. @valerauko 