### PR TITLE
Manually tag conflicting routes

### DIFF
--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -381,7 +381,9 @@
                       :else mixed-router)]
 
          (when-let [conflicts (:conflicts opts)]
-           (when path-conflicting (conflicts path-conflicting)))
+           (when-let [conflict-report (impl/unresolved-conflicts
+                                        path-conflicting)]
+             (conflicts conflict-report)))
 
          (when name-conflicting
            (exception/fail! :name-conflicts name-conflicting))

--- a/modules/reitit-core/src/reitit/exception.cljc
+++ b/modules/reitit-core/src/reitit/exception.cljc
@@ -26,11 +26,18 @@
   (str message (if data (str "\n\n" (pr-str data)))))
 
 (defmethod format-exception :path-conflicts [_ _ conflicts]
-  (apply str "Router contains conflicting route paths:\n\n"
-         (mapv
-           (fn [[[path] vals]]
-             (str "   " path "\n-> " (str/join "\n-> " (mapv first vals)) "\n\n"))
-           conflicts)))
+  (letfn [(resolve-str [path route-data]
+            (str (if (:conflicting route-data) "   " "-> ")
+                 path " " (not-empty (select-keys route-data [:conflicting]))))]
+    (apply str "Router contains conflicting route paths:\n\n"
+           (mapv
+             (fn [[[path route-data] vals]]
+               (str (resolve-str path route-data)
+                    "\n"
+                    (str/join "\n" (mapv (fn [[path route-data]]
+                                           (resolve-str path route-data)) vals))
+                    "\n\n"))
+             conflicts))))
 
 (defmethod format-exception :name-conflicts [_ _ conflicts]
   (apply str "Router contains conflicting route names:\n\n"

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -85,6 +85,15 @@
             routes)
       (not-empty)))
 
+(defn unresolved-conflicts [path-conflicting]
+  (-> (into {}
+            (remove (fn [[[_ route-data] conflicts]]
+                      (and (:conflicting route-data)
+                           (every? (comp :conflicting second)
+                                   conflicts)))
+                    path-conflicting))
+      (not-empty)))
+
 (defn conflicting-paths [conflicts]
   (->> (for [[p pc] conflicts]
          (conj (map first pc) (first p)))

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -90,8 +90,8 @@
             (remove (fn [[[_ route-data] conflicts]]
                       (and (:conflicting route-data)
                            (every? (comp :conflicting second)
-                                   conflicts)))
-                    path-conflicting))
+                                   conflicts))))
+            path-conflicting)
       (not-empty)))
 
 (defn conflicting-paths [conflicts]

--- a/modules/reitit-dev/src/reitit/dev/pretty.cljc
+++ b/modules/reitit-dev/src/reitit/dev/pretty.cljc
@@ -270,22 +270,29 @@
   [:group
    (text "Router contains conflicting route paths:")
    [:break] [:break]
-   (into
-     [:group]
-     (mapv
-       (fn [[[path] vals]]
-         [:group
-          [:span "   " (text path)]
-          [:break]
-          (into
-            [:group]
-            (map
-              (fn [p] [:span (color :grey "-> " p) [:break]])
-              (mapv first vals)))
-          [:break]])
-       conflicts))
+   (letfn [(path-report [path route-data]
+             [:span (color :grey
+                           (if (:conflicting route-data) "   " "-> ")
+                           path
+                           " ")
+              (edn (not-empty (select-keys route-data [:conflicting])))])]
+     (into
+       [:group]
+       (mapv
+         (fn [[[path route-data] vals]]
+           [:group
+            (path-report path route-data)
+            (into
+              [:group]
+              (map
+                (fn [[path route-data]] (path-report path route-data))
+                vals))
+            [:break]])
+         conflicts)))
    [:span (text "Either fix the conflicting paths or disable the conflict resolution")
-    [:break] (text "by setting a router option: ") [:break] [:break]
+    [:break] (text "by setting route data for conflicting route: ") [:break] [:break]
+    (edn {:conflicting true} {:margin 3})
+    [:break] (text "or by setting a router option: ") [:break] [:break]
     (edn {:conflicts nil} {:margin 3})]
    [:break]
    (color :white "https://cljdoc.org/d/metosin/reitit/CURRENT/doc/basics/route-conflicts")

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -337,7 +337,26 @@
               #"Router contains conflicting route paths"
               (r/router
                 [["/a"] ["/a"]]))))
-      (testing "can be configured to ignore"
+      (testing "can be configured to ignore with route data"
+        (are [paths expected]
+          (let [router (r/router paths)]
+            (is (not (nil? router)))
+            (is (= expected (r/router-name router))))
+          [["/a" {:conflicting true}]
+           ["/a" {:conflicting true}]] :quarantine-router
+          [["/a" {:conflicting true}]
+           ["/:b" {:conflicting true}]
+           ["/c" {:conflicting true}]
+           ["/*d" {:conflicting true}]] :quarantine-router)
+        (testing "unmarked path conflicts throw"
+          (are [paths]
+            (is (thrown-with-msg?
+                  ExceptionInfo
+                  #"Router contains conflicting route paths"
+                  (r/router paths)))
+            [["/a"] ["/a" {:conflicting true}]]
+            [["/a" {:conflicting true}] ["/a"]])))
+      (testing "can be configured to ignore with router option"
         (is (not (nil? (r/router [["/a"] ["/a"]] {:conflicts nil})))))))
 
   (testing "name conflicts"

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -347,7 +347,19 @@
           [["/a" {:conflicting true}]
            ["/:b" {:conflicting true}]
            ["/c" {:conflicting true}]
-           ["/*d" {:conflicting true}]] :quarantine-router)
+           ["/*d" {:conflicting true}]] :quarantine-router
+          [["/:a"
+            ["/:b" {:conflicting true}]
+            ["/:c" {:conflicting true}]
+            ["/:d"
+             ["/:e" {:conflicting true}]
+             ["/:f" {:conflicting true}]]]] :quarantine-router
+          [["/:a" {:conflicting true}
+            ["/:b"]
+            ["/:c"]
+            ["/:d"
+             ["/:e"]
+             ["/:f"]]]] :quarantine-router)
         (testing "unmarked path conflicts throw"
           (are [paths]
             (is (thrown-with-msg?


### PR DESCRIPTION
Fixes #324 

Introduces a new route data key `:conflicting` which takes a logically true value and, upon true, excludes the route from the path conflicts report. The report is used during router initialization in conjunction with the `:conflicts` check to see if there are still any paths that are not ignored and are conflicting.