### PR TITLE
Update to latest ring-swagger-ui

### DIFF
--- a/doc/ring/swagger.md
+++ b/doc/ring/swagger.md
@@ -63,6 +63,8 @@ Webjars also hosts a [version](https://github.com/webjars/swagger-ui) of the swa
 
 **NOTE**: Currently, swagger-ui module is just for Clojure. ClojureScript-support welcome as a PR!
 
+**NOTE:** If you want to use swagger-ui 2.x you can do so by explicitly downgrading `metosin/ring-swagger-ui` to `2.2.10`.
+
 ## Examples
 
 ### Simple example

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                          [metosin/reitit-frontend "0.3.10"]
                          [metosin/reitit-sieppari "0.3.10"]
                          [metosin/reitit-pedestal "0.3.10"]
-                         [metosin/ring-swagger-ui "2.2.10"]
+                         [metosin/ring-swagger-ui "3.24.3"]
                          [metosin/spec-tools "0.10.0"]
                          [metosin/schema-tools "0.12.1"]
                          [metosin/muuntaja "0.6.6"]


### PR DESCRIPTION
This updates `ring-swagger-ui`, thereby updating `swagger-ui` to version 3. Note that `swagger-ui` 3.x [supports different versions of the OpenAPI spec](https://github.com/swagger-api/swagger-ui/tree/a24957e8ce938de162a05a02f166b3120b1a1b06) compared to the one used before. This should not be a problem because the `swagger.json` generated by `reitit-swagger` uses the `swagger` fromat `2.0`, at least in my case. I don't know if there are cases where this might cause a problem.