### PR TITLE
enforcing the start path to mount the external handler with /

### DIFF
--- a/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
+++ b/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
@@ -13,7 +13,7 @@
      | :parameter       | optional name of the wildcard parameter, defaults to unnamed keyword `:`
      | :root            | optional resource root, defaults to `\"swagger-ui\"`
      | :url             | path to swagger endpoint, defaults to `/swagger.json`
-     | :path            | optional path to mount the handler to. Works only if mounted outside of a router.
+     | :path            | optional path to mount the handler to. Works only if mounted outside of a router and it should always start with /
      | :config          | parameters passed to swaggger-ui as-is.
 
      See https://github.com/swagger-api/swagger-ui/tree/2.x#parameters
@@ -36,6 +36,7 @@
       (let [config-json (fn [{:keys [url config]}] (j/write-value-as-string (merge config {:url url})))
             conf-js (fn [opts] (str "window.API_CONF = " (config-json opts) ";"))
             options (as-> options $
+                          (update $ :path (fn [path] (if-not (str/starts-with? path "/") (str "/" path) path)))
                           (update $ :root (fnil identity "swagger-ui"))
                           (update $ :url (fnil identity "/swagger.json"))
                           (assoc $ :paths {"/conf.js" {:headers {"Content-Type" "application/javascript"}


### PR DESCRIPTION
I interpret the "enforcement" in the path parameter as "If it does not have a / character at the beginning, we must add it there". I also added a small text in the docstring to inform this decision, so an error related to / addition should be clear.

It fixes #94 

Question: What you think about refactoring the code to not use `as->`  as first item of the threading process?
Suggestion:
```clj
(let [config-json (fn [{:keys [url config]}] (j/write-value-as-string (merge config {:url url})))
      conf-js (fn [opts] (str "window.API_CONF = " (config-json opts) ";"))
      include-paths (fn [opts] (assoc opts :paths {"/conf.js" {:headers {"Content-Type" "application/javascript"}
                                                               :status 200
                                                               :body (conf-js opts)}
                                                   "/config.json" {:headers {"Content-Type" "application/json"}
                                                                   :status 200
                                                                   :body (config-json opts)}}))
      options (-> options
                (update :path (fn [path] (if-not (str/starts-with? path "/") (str "/" path) path)))
                (update :root (fnil identity "swagger-ui"))
                (update :url (fnil identity "/swagger.json"))
                include-paths)]
        (ring/routes
         (ring/create-resource-handler options)))
```

The [clojure don'ts](https://stuartsierra.com/2018/07/15/clojure-donts-thread-as) post from Stuart Sierra got stuck in my head for a while. I always thought about it more from the aesthetisc point of view. But in fact, when I see this happening, there is an overhead thinking about  "some types are changing" while chaining the operations that I may want to avoid in future readings of the code. 

When I intentionally want this to be explicit, the usage of `as->` is just fine. But when this is more like an implementation detail, I rather refactor the function below and not bother the client to even consider this thoughts. What you think about this?