### PR TITLE
Add janus to opensensors benchmark

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -133,7 +133,8 @@
                                    [aleph "0.4.6"]
                                    [ring/ring-defaults "0.3.2"]
                                    [ataraxy "0.4.2"]
-                                   [bidi "2.1.6"]]}
+                                   [bidi "2.1.6"]
+                                   [janus "1.3.0"]]}
              :analyze {:jvm-opts ^:replace ["-server"
                                             "-Dclojure.compiler.direct-linking=true"
                                             "-XX:+PrintCompilation"


### PR DESCRIPTION
@ikitommi gave me the 👍 on clojurians, so here it is!

[Janus](https://github.com/cch1/janus) is a zipper-based data-centric router for clj/s

There are some Rich-comment-forms after the routing table since the original repo is a little light on usage examples, but I'd be happy to remove them.

Speed-wise, it positioned itself between `calfpath-unroll` and `compojure`.

There might still be some squeezing potential re: the routing table conciseness and speed, but I believe all the low-hanging fruits were collected after a review from the library author.

Once again, thanks for the extraordinary work!