### PR TITLE
Pass malli options to extract-parameter fn

### DIFF
--- a/modules/reitit-malli/src/reitit/coercion/malli.cljc
+++ b/modules/reitit-malli/src/reitit/coercion/malli.cljc
@@ -75,18 +75,18 @@
 ;; swagger
 ;;
 
-(defmulti extract-parameter (fn [in _] in))
+(defmulti extract-parameter (fn [in _ _] in))
 
-(defmethod extract-parameter :body [_ schema]
-  (let [swagger-schema (swagger/transform schema {:in :body, :type :parameter})]
+(defmethod extract-parameter :body [_ schema options]
+  (let [swagger-schema (swagger/transform schema (merge options {:in :body, :type :parameter}))]
     [{:in "body"
       :name (:title swagger-schema "")
       :description (:description swagger-schema "")
       :required (not= :maybe (m/name schema))
       :schema swagger-schema}]))
 
-(defmethod extract-parameter :default [in schema]
-  (let [{:keys [properties required]} (swagger/transform schema {:in in, :type :parameter})]
+(defmethod extract-parameter :default [in schema options]
+  (let [{:keys [properties required]} (swagger/transform schema (merge options {:in in, :type :parameter}))]
     (mapv
       (fn [[k {:keys [type] :as schema}]]
         (merge
@@ -135,7 +135,7 @@
                       (if parameters
                         {:parameters
                          (->> (for [[in schema] parameters
-                                    parameter (extract-parameter in (compile schema))]
+                                    parameter (extract-parameter in (compile schema) options)]
                                 parameter)
                               (into []))})
                       (if responses


### PR DESCRIPTION
Reitit swagger fails to generate swagger schema when using custom malli registry:

```clojure
["/api"
 {:swagger    {:id ::app}
  :coercion   (reitit.coercion.malli/create {:options {:registry @custom-registry}})
  ["/swagger.json"
   {:get (reitit.swagger/create-swagger-handler)}]}]
```