### PR TITLE
-href on FragmentHistory should include the path

### DIFF
--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -47,7 +47,7 @@
         fragment)))
   (-href [this path]
     (if path
-      (str "#" path))))
+      (str  (.. js/window -location -pathname) "#" path))))
 
 (defn- closest-by-tag [el tag]
   ;; nodeName is upper case for HTML always,


### PR DESCRIPTION
If the path is not included and you create a link it will always point to 
#/$path
but your index file may not be root for instance
/version/test/index.html#/$path