### PR TITLE
Update dynamic_extensions.md

### DIFF
--- a/doc/ring/dynamic_extensions.md
+++ b/doc/ring/dynamic_extensions.md
@@ -9,9 +9,9 @@ Example middleware to guard routes based on user roles:
 (require '[clojure.set :as set])
 
 (defn wrap-enforce-roles [handler]
-  (fn [{::keys [roles] :as request}]
+  (fn [{:keys [my-roles] :as request}]
     (let [required (some-> request (ring/get-match) :data ::roles)]
-      (if (and (seq required) (not (set/subset? required roles)))
+      (if (and (seq required) (not (set/subset? required my-roles)))
         {:status 403, :body "forbidden"}
         (handler request)))))
 ```
@@ -48,7 +48,7 @@ Anonymous access to guarded route:
 Authorized access to guarded route:
 
 ```clj
-(app {:request-method :get, :uri "/api/admin/ping", ::roles #{:admin}})
+(app {:request-method :get, :uri "/api/admin/ping", :my-roles #{:admin}})
 ; {:status 200, :body "ok"}
 ```
 


### PR DESCRIPTION
I find the clarity of this example important because the implementation of (ring/get-match) https://github.com/metosin/reitit/blob/c23f591283883bcebae482e723aa34284cfd048c/modules/reitit-ring/src/reitit/ring.cljc#L309 doesn't explain what's going on here.

I find the destructing of the qualified keyword `::roles` unnecessary to the example. To this end I propose using an unqualified keyword.

Additionally there is a collision between the name of the required rolls to access the route and the name of the roles held by the user making the request. To this end I propose having the roles held by the user named `:my-roles`