### PR TITLE
Quick router creation

### DIFF
--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -301,7 +301,7 @@
   ([compiled-routes]
    (quarantine-router compiled-routes {}))
   ([compiled-routes opts]
-   (let [conflicting-paths (-> compiled-routes (impl/path-conflicting-routes opts) impl/conflicting-paths)
+   (let [conflicting-paths (impl/conflicting-paths (or (::path-conflicting opts) (impl/path-conflicting-routes compiled-routes opts)))
          conflicting? #(contains? conflicting-paths (first %))
          {conflicting true, non-conflicting false} (group-by conflicting? compiled-routes)
          linear-router (linear-router conflicting opts)
@@ -389,7 +389,7 @@
          (when-let [validate (:validate opts)]
            (validate compiled-routes opts))
 
-         (router compiled-routes opts))
+         (router compiled-routes (assoc opts ::path-conflicting path-conflicting)))
 
        (catch #?(:clj Exception, :cljs js/Error) e
          (throw ((get opts :exception identity) e)))))))

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -179,7 +179,7 @@
                (URLDecoder/decode
                  (if (.contains ^String s "+")
                    (.replace ^String s "+" "%2B")
-                   s)
+                   ^String s)
                  "UTF-8"))
        :cljs (js/decodeURIComponent s))))
 

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -71,7 +71,7 @@
 
 (defn resolve-routes [raw-routes {:keys [coerce] :as opts}]
   (cond->> (->> (walk raw-routes opts) (map-data merge-data))
-    coerce (into [] (keep #(coerce % opts)))))
+           coerce (into [] (keep #(coerce % opts)))))
 
 (defn path-conflicting-routes [routes opts]
   (-> (into {}

--- a/modules/reitit-core/src/reitit/trie.cljc
+++ b/modules/reitit-core/src/reitit/trie.cljc
@@ -132,17 +132,18 @@
       (concat [(subs x i)] xs)
       xs)))
 
+(defn conflicting-parts? [parts1 parts2]
+  (let [[[s1 & ss1] [s2 & ss2]] (-slice-start parts1 parts2)]
+    (cond
+      (= s1 s2 nil) true
+      (or (nil? s1) (nil? s2)) false
+      (or (catch-all? s1) (catch-all? s2)) true
+      (or (wild? s1) (wild? s2)) (recur (-slice-end s1 ss1) (-slice-end s2 ss2))
+      (not= s1 s2) false
+      :else (recur ss1 ss2))))
+
 (defn conflicting-paths? [path1 path2 opts]
-  (loop [parts1 (split-path path1 opts)
-         parts2 (split-path path2 opts)]
-    (let [[[s1 & ss1] [s2 & ss2]] (-slice-start parts1 parts2)]
-      (cond
-        (= s1 s2 nil) true
-        (or (nil? s1) (nil? s2)) false
-        (or (catch-all? s1) (catch-all? s2)) true
-        (or (wild? s1) (wild? s2)) (recur (-slice-end s1 ss1) (-slice-end s2 ss2))
-        (not= s1 s2) false
-        :else (recur ss1 ss2)))))
+  (conflicting-parts? (split-path path1 opts) (split-path path2 opts)))
 
 ;;
 ;; Creating Tries

--- a/perf-test/clj/reitit/router_creation_perf_test.clj
+++ b/perf-test/clj/reitit/router_creation_perf_test.clj
@@ -1,0 +1,43 @@
+(ns reitit.router-creation-perf-test
+  (:require [reitit.perf-utils :refer [bench!]]
+            [reitit.core :as r]
+            [clojure.string :as str])
+  (:import (java.util Random)))
+
+;;
+;; start repl with `lein perf repl`
+;; perf measured with the following setup:
+;;
+;; Model Name:            MacBook Pro
+;; Model Identifier:      MacBookPro113
+;; Processor Name:        Intel Core i7
+;; Processor Speed:       2,5 GHz
+;; Number of Processors:  1
+;; Total Number of Cores: 4
+;; L2 Cache (per Core):   256 KB
+;; L3 Cache:              6 MB
+;; Memory:                16 GB
+;;
+
+(defn random [^long seed]
+  (Random. seed))
+
+(defn rand-str [^Random rnd len]
+  (apply str (take len (repeatedly #(char (+ (.nextInt rnd 26) 97))))))
+
+(defn route [rnd]
+  (str/join "/" (repeatedly (+ 2 (.nextInt rnd 8)) (fn [] (rand-str rnd (.nextInt rnd 10))))))
+
+(def hundred-routes
+  (let [rnd (random 1)]
+    (mapv (fn [n] [(route rnd) (keyword (str "route" n))]) (range 100))))
+
+(defn bench-routers []
+  ;; 104ms
+  (bench! "default" (r/router hundred-routes))
+
+  ;; 7ms
+  (bench! "linear" (r/router hundred-routes {:router r/linear-router, :conflicts nil})))
+
+(comment
+  (bench-routers))

--- a/perf-test/clj/reitit/router_creation_perf_test.clj
+++ b/perf-test/clj/reitit/router_creation_perf_test.clj
@@ -40,6 +40,7 @@
   (suite "non-conflicting")
 
   ;; 104ms
+  ;;  11ms (reuse parts in conflict resolution)
   (bench! "default" (r/router hundred-routes))
 
   ;; 7ms
@@ -50,6 +51,7 @@
 
     ;; 205ms
     ;; 105ms (cache path-conflicts)
+    ;;  13ms (reuse parts in conflict resolution)
     (bench! "default" (r/router routes {:conflicts nil}))))
 
 (comment


### PR DESCRIPTION
* Reuse path splitting results in path conflict resolution, O(n2) -> O(n) complexity
* common path-conflict resolution can be disabled by defining `:router` and setting `:conflicts` to nil. With 100 routes, a `r/linear-router` creation is ~15x faster (7ms vs 100ms)
  * e.g. `(r/router routes {:router r/linear-router, :conflicts nil})` forces a linear router, with no conflict checking (fast to create, slower to match)
* quarantine-router resolves path-conflicts just once (2x faster)

### With 100 conflicting routes, path conflict resolution 200ms -> 13ms

~~Still, the path conflict resolution is really slow. Here's a flamegraph:~~

<img width="887" alt="Screenshot 2020-04-26 at 22 22 18" src="https://user-images.githubusercontent.com/567532/80317496-d0a9de80-880c-11ea-8541-7b1aa6e740ee.png">
