### PR TITLE
Fix link in default_middleware.md

### DIFF
--- a/doc/ring/default_middleware.md
+++ b/doc/ring/default_middleware.md
@@ -23,6 +23,10 @@ Any Ring middleware can be used with `reitit-ring`, but using data-driven middle
 
 See [Exception Handling with Ring](exceptions.md).
 
+## Content Negotiation
+
+See [Content Negotiation](content_negotiation.md).
+
 ## Multipart Request Handling
 
 Wrapper for [Ring Multipart Middleware](https://github.com/ring-clojure/ring/blob/master/ring-core/src/ring/middleware/multipart_params.clj). Emits swagger `:consumes` definitions automatically.


### PR DESCRIPTION
"Content Negotation" was moved to its own page. This commit adds a
section with a link to the new page, similar to the way the "Exception
Handling" section is presented.