### PR TITLE
fix: coercion.malli use m/type

### DIFF
--- a/modules/reitit-malli/src/reitit/coercion/malli.cljc
+++ b/modules/reitit-malli/src/reitit/coercion/malli.cljc
@@ -86,7 +86,7 @@
     [{:in "body"
       :name (:title swagger-schema "body")
       :description (:description swagger-schema "")
-      :required (not= :maybe (m/name schema))
+      :required (not= :maybe (m/type schema))
       :schema swagger-schema}]))
 
 (defmethod extract-parameter :default [in schema options]


### PR DESCRIPTION
Renames `m/name` to `m/type` per the breaking change introduced in malli
4880734d554511f16fee9c1d28a9d340c8b632c1.

Worth noting that this doesn't update the managed dependency in `project.clj` because a release with `m/type` hasn't been cut yet.