### PR TITLE
Replace top-level `:tags` with `[:swagger :tags]` path in documentation

### DIFF
--- a/modules/reitit-swagger/src/reitit/swagger.cljc
+++ b/modules/reitit-swagger/src/reitit/swagger.cljc
@@ -29,7 +29,6 @@
   | --------------|-------------|
   | :swagger      | map of any swagger-data. Must have `:id` (keyword or sequence of keywords) to identify the api
   | :no-doc       | optional boolean to exclude endpoint from api docs
-  | :tags         | optional set of string or keyword tags for an endpoint api docs
   | :summary      | optional short string summary of an endpoint
   | :description  | optional long description of an endpoint. Supports http://spec.commonmark.org/
 
@@ -52,7 +51,7 @@
                :handler reitit.swagger/swagger-spec-handler}}]
 
        [\"/plus\"
-        {:get {:tags #{:math}
+        {:get {:swagger {:tags \"math\"}
                :summary \"adds numbers together\"
                :description \"takes `x` and `y` query-params and adds them together\"
                :parameters {:query {:x int?, :y int?}}


### PR DESCRIPTION
Change `:tags` usage in documentation as mentioned in #375 