### PR TITLE
Cleanup test namespaces

### DIFF
--- a/test/clj/reitit/http_test.clj
+++ b/test/clj/reitit/http_test.clj
@@ -171,7 +171,7 @@
           (testing "handler rejects"
             (is (= -406 (:status (app {:request-method :get, :uri "/pong"}))))))))))
 
-(deftest default-options-handler-test
+(deftest deprecated-default-options-handler-test
   (testing "Assertion fails when using deprecated options-handler"
     (is (thrown? ExceptionInfo (ring/router [] {::ring/default-options-handler (fn [_])})))))
 

--- a/test/cljc/reitit/swagger_test.clj
+++ b/test/cljc/reitit/swagger_test.clj
@@ -7,7 +7,6 @@
             [reitit.coercion.spec :as spec]
             [reitit.coercion.malli :as malli]
             [reitit.coercion.schema :as schema]
-            [schema.core :refer [Int]]
             [muuntaja.core :as m]
             [spec-tools.data-spec :as ds]
             [schema.core :as s]))
@@ -77,11 +76,11 @@
        ["/schema" {:coercion schema/coercion}
         ["/plus/*z"
          {:get {:summary "plus"
-                :parameters {:query {:x Int, :y Int}
-                             :path {:z Int}}
+                :parameters {:query {:x s/Int, :y s/Int}
+                             :path {:z s/Int}}
                 :swagger {:responses {400 {:schema {:type "string"}
                                            :description "kosh"}}}
-                :responses {200 {:body {:total Int}}
+                :responses {200 {:body {:total s/Int}}
                             500 {:description "fail"}}
                 :handler (fn [{{{:keys [x y]} :query
                                 {:keys [z]} :path} :parameters}]


### PR DESCRIPTION
Make `default-options-handler-test` run by renaming the test and clean up duplicate require of `schema.core` in `test/cljc/reitit/swagger_test.clj`.