### PR TITLE
Issue 217 consume form params

### DIFF
--- a/modules/reitit-interceptors/src/reitit/http/interceptors/parameters.clj
+++ b/modules/reitit-interceptors/src/reitit/http/interceptors/parameters.clj
@@ -11,6 +11,10 @@
   :params       - a merged map of all types of parameter"
   []
   {:name ::parameters
+   :compile (fn [{:keys [parameters]} _]
+              (if (and (some? (:form parameters)) (nil? (:body parameters)))
+                {:data {:swagger {:consumes ["application/x-www-form-urlencoded"]}}}
+                {}))
    :enter (fn [ctx]
             (let [request (:request ctx)]
               (assoc ctx :request (params/params-request request))))})

--- a/modules/reitit-middleware/src/reitit/ring/middleware/parameters.clj
+++ b/modules/reitit-middleware/src/reitit/ring/middleware/parameters.clj
@@ -10,4 +10,8 @@
   :form-params  - a map of parameters from the body
   :params       - a merged map of all types of parameter"
   {:name ::parameters
+   :compile (fn [{:keys [parameters]} _]
+              (if (and (some? (:form parameters)) (nil? (:body parameters)))
+                {:data {:swagger {:consumes ["application/x-www-form-urlencoded"]}}}
+                {}))
    :wrap params/wrap-params})

--- a/test/clj/reitit/ring/middleware/muuntaja_test.clj
+++ b/test/clj/reitit/ring/middleware/muuntaja_test.clj
@@ -34,19 +34,24 @@
                  ["/just-edn"
                   {:muuntaja just-edn
                    :get identity}]
+                 ["/form-params"
+                  {:post {:parameters {:form {:x string?}}
+                          :handler identity}}]
                  ["/swagger.json"
                   {:get {:no-doc true
                          :handler (swagger/create-swagger-handler)}}]]
                 {:data {:muuntaja m/instance
                         :middleware [muuntaja/format-middleware]}}))
-        spec (fn [path]
+        spec (fn [method path]
                (let [path (keyword path)]
                  (-> {:request-method :get :uri "/swagger.json"}
                      (app) :body
                      (->> (m/decode m/instance "application/json"))
-                     :paths path :get)))
-        produces (comp set :produces spec)
-        consumes (comp set :consumes spec)]
+                     :paths path method)))
+        produces (comp set :produces (partial spec :get))
+        consumes (comp set :consumes (partial spec :get))
+        post-produces (comp set :produces (partial spec :post))
+        post-consumes (comp set :consumes (partial spec :post))]
 
     (testing "with defaults"
       (let [path "/defaults"]
@@ -82,7 +87,12 @@
       (let [path "/just-edn"]
         (is (= #{"application/edn"}
                (produces path)
-               (consumes path)))))))
+               (consumes path)))))
+    (testing "form parameters swagger-data"
+      (let [path "/form-params"]
+        (is (= #{}
+               (post-produces path)
+               (post-consumes path)))))))
 
 (deftest muuntaja-swagger-parts-test
   (let [app (ring/ring-handler
@@ -100,16 +110,34 @@
                                 muuntaja/format-response-middleware
                                 muuntaja/format-request-middleware]
                    :get identity}]
+                 ["/form-request"
+                  {:middleware [muuntaja/format-negotiate-middleware
+                                muuntaja/format-request-middleware]
+                   :post {:parameters {:form {:x string?}}
+                          :handler identity}}]
+                 ["/form-response"
+                  {:middleware [muuntaja/format-negotiate-middleware
+                                muuntaja/format-response-middleware]
+                   :post {:parameters {:form {:x string?}}
+                          :handler identity}}]
+                 ["/form-with-both"
+                  {:middleware [muuntaja/format-negotiate-middleware
+                                muuntaja/format-response-middleware
+                                muuntaja/format-request-middleware]
+                   :post {:parameters {:form {:x string?}}
+                          :handler identity}}]
 
                  ["/swagger.json"
                   {:get {:no-doc true
                          :handler (swagger/create-swagger-handler)}}]]
                 {:data {:muuntaja m/instance}}))
-        spec (fn [path]
+        spec (fn [method path]
                (-> {:request-method :get :uri "/swagger.json"}
-                   (app) :body :paths (get path) :get))
-        produces (comp :produces spec)
-        consumes (comp :consumes spec)]
+                   (app) :body :paths (get path) method))
+        produces (comp :produces (partial spec :get))
+        consumes (comp :consumes (partial spec :get))
+        post-produces (comp :produces (partial spec :post))
+        post-consumes (comp :consumes (partial spec :post))]
 
     (testing "just request formatting"
       (let [path "/request"]
@@ -129,7 +157,7 @@
                (produces path)))
         (is (nil? (consumes path)))))
 
-    (testing "just response formatting"
+    (testing "request and response formatting"
       (let [path "/both"]
         (is (= #{"application/json"
                  "application/transit+msgpack"
@@ -140,4 +168,16 @@
                  "application/transit+msgpack"
                  "application/transit+json"
                  "application/edn"}
-               (consumes path)))))))
+               (consumes path)))))
+    (testing "just request formatting for form params"
+      (let [path "/form-request"]
+        (is (nil? (post-produces path)))
+        (is (nil? (post-consumes path)))))
+    (testing "just response formatting for form params"
+      (let [path "/form-response"]
+        (is (nil? (post-produces path)))
+        (is (nil? (post-consumes path)))))
+    (testing "just request formatting for form params"
+      (let [path "/form-with-both"]
+        (is (nil? (post-produces path)))
+        (is (nil? (post-consumes path)))))))

--- a/test/clj/reitit/ring/middleware/parameters_test.clj
+++ b/test/clj/reitit/ring/middleware/parameters_test.clj
@@ -1,7 +1,8 @@
 (ns reitit.ring.middleware.parameters-test
   (:require [clojure.test :refer [deftest testing is]]
             [reitit.ring.middleware.parameters :as parameters]
-            [reitit.ring :as ring]))
+            [reitit.ring :as ring]
+            [reitit.swagger :as swagger]))
 
 (deftest parameters-test
   (let [app (ring/ring-handler
@@ -13,3 +14,22 @@
            (app {:request-method :get
                  :uri "/ping"
                  :query-string "kikka=kukka"})))))
+
+(deftest parameters-swagger-test
+  (let [app (ring/ring-handler
+              (ring/router
+                [["/form-params" {:post {:parameters {:form {:x string?}}
+                                         :handler identity}}]
+                 ["/body-params" {:post {:parameters {:body {:x string?}}
+                                        :handler identity}}]
+                 ["/swagger.json" {:get {:no-doc true
+                                        :handler (swagger/create-swagger-handler)}}]]
+                {:data {:middleware [parameters/parameters-middleware]}}))
+        spec (fn [path]
+               (-> {:request-method :get :uri "/swagger.json"}
+                   app
+                   (get-in [:body :paths path :post])))]
+    (testing "with form parameters"
+      (is (= ["application/x-www-form-urlencoded"] (:consumes (spec "/form-params")))))
+    (testing "with body parameters"
+      (is (= nil (:consumes (spec "/body-params")))))))


### PR DESCRIPTION
Automatically publish `:swagger {:consumes ["application/x-www-form-urlencoded"]}` for parameters middleware/interceptor namespaces when endpoint has `:form` but no `:body` parameters present.

In similar situation omit swagger-data for muuntaja middleware/interceptor to avoid problems with middleware ordering.

Closes #217 