### PR TITLE
frontend: Match HTML5 and fragment router behavior, no-op on routing to current path

### DIFF
--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -46,7 +46,7 @@
         "/"
         fragment)))
   (-href [this path]
-    (if path
+    (when path
       (str "#" path))))
 
 (defn- closest-by-tag [el tag]
@@ -54,7 +54,7 @@
   ;; for XML or XHTML it would be in the original case.
   (let [tag (.toUpperCase tag)]
     (loop [el el]
-      (if el
+      (when el
         (if (= tag (.-nodeName el))
           el
           (recur (.-parentNode el)))))))
@@ -74,7 +74,7 @@
   if anchor href matches the route tree, and in this case
   the page location is updated using History API."
   [router e el uri]
-  (let [current-domain (if (exists? js/location)
+  (let [current-domain (when (exists? js/location)
                          (.getDomain (.parse Uri js/location)))]
     (and (or (and (not (.hasScheme uri)) (not (.hasDomain uri)))
              (= current-domain (.getDomain uri)))
@@ -96,8 +96,7 @@
   (-init [this]
     (let [last-path (atom nil)
           this (assoc this :last-path last-path)
-          handler (fn [e]
-                    (-on-navigate this (-get-path this)))
+          handler (fn [_] (-on-navigate this (-get-path this)))
 
           ignore-anchor-click-predicate (or (:ignore-anchor-click? this)
                                             ignore-anchor-click?)
@@ -171,8 +170,7 @@
               (map->Html5History opts))))))
 
 (defn stop! [history]
-  (if history
-    (-stop history)))
+  (when history (-stop history)))
 
 (defn href
   ([history k]


### PR DESCRIPTION
The fragment router has some logic to avoid calling `on-navigate` and pushing history when it would do a no-op route to the same path as the current path. I notice that the HTML5 router does not do this, so when you click on a link pointing to the the current page, it keeps pushing it onto the history. This PR makes the HTML5 router behavior match the fragment router behavior. 

I don't know if there are any cases where you might want to call `on-navigate` even if you're trying to route to the same route. Fulcro's dynamic routers do a no-op in this case too.