### PR TITLE
Fix resource handler path matching

### DIFF
--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -208,9 +208,9 @@
            join-paths (fn [& paths]
                         (str/replace (str/replace (str/join "/" paths) #"([/]+)" "/") #"/$" ""))
            response (fn [path]
-                           (if-let [response (or (paths (join-paths "/" path))
-                                                 (response-fn path options))]
-                             (response/content-type response (mime-type/ext-mime-type path))))
+                      (if-let [response (or (paths (join-paths "/" path))
+                                            (response-fn path options))]
+                        (response/content-type response (mime-type/ext-mime-type path))))
            path-or-index-response (fn [path uri]
                                     (or (response path)
                                         (loop [[file & files] index-files]
@@ -221,8 +221,8 @@
            handler (if path
                      (fn [request]
                        (let [uri (:uri request)]
-                         (if-let [path (if (>= (count uri) path-size) (subs uri path-size))]
-                           (path-or-index-response path uri))))
+                         (if (.startsWith uri path)
+                           (path-or-index-response (subs uri path-size) uri))))
                      (fn [request]
                        (let [uri (:uri request)
                              path (-> request :path-params parameter)]

--- a/test/clj/reitit/http_test.clj
+++ b/test/clj/reitit/http_test.clj
@@ -491,6 +491,8 @@
 
             (testing "not found"
               (let [response (app (request "/not-found"))]
+                (is (= 404 (:status response))))
+              (let [response (app {:uri "/XXXXX/hello.json" :request-method :get})]
                 (is (= 404 (:status response)))))
 
             (testing "3-arity"


### PR DESCRIPTION
File/resource handler strips path length amount of characters from request uri when finding resource files. 
This causes incorrect uris to respond with resources/redirects instead of not found.

i.e. Swagger UI handler
```
(ring/routes
    (swagger-ui/create-swagger-ui-handler {:path "/swagger"})
    (ring/create-default-handler))
```
Swagger UI should be available in uri `/swagger` but it can incorrectly be found from `/aaaaaaa` or `/a/b/c/d` or any other uri with same length.

This also causes wrong Swagger UI to load when using multiple swagger-ui-handlers:
```
(ring/routes
    (swagger-ui/create-swagger-ui-handler {:path "/doc/v1" :url "swagger-v1.json"})
    (swagger-ui/create-swagger-ui-handler {:path "/doc/v2" :url "swagger-v2.json"})
    (ring/create-default-handler))
```
Request to `/doc/v2` redirects incorrectly to `/doc/v1/index.html` because it's the first match with same path length.

This PR fixes the issue, but also makes path to uri comparison case sensitive. I'm not sure whether it should be.