### PR TITLE
Add :conflicting to route data spec

### DIFF
--- a/modules/reitit-core/src/reitit/spec.cljc
+++ b/modules/reitit-core/src/reitit/spec.cljc
@@ -40,7 +40,9 @@
 (s/def ::name keyword?)
 (s/def ::handler fn?)
 (s/def ::no-doc boolean?)
-(s/def ::default-data (s/keys :opt-un [::name ::handler ::no-doc]))
+(s/def ::conflicting boolean?)
+(s/def ::default-data
+  (s/keys :opt-un [::name ::handler ::no-doc ::conflicting]))
 
 ;;
 ;; router


### PR DESCRIPTION
This addresses issue #376 by adding the `::conflicting` spec in the `reitit.spec/default-data`.