### PR TITLE
Update create-swagger-ui-handler

### DIFF
--- a/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
+++ b/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
@@ -14,7 +14,7 @@
      | :path            | optional path to mount the handler to. Works only if mounted outside of a router.
      | :config          | parameters passed to swaggger-ui as-is.
 
-     See https://github.com/swagger-api/swagger-ui/tree/2.x#parameters
+     See https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md
      for all available :config options
 
      Examples:

--- a/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
+++ b/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
@@ -32,14 +32,10 @@
       (create-swagger-ui-handler nil))
      ([options]
       (let [config-json (fn [{:keys [url config]}] (j/write-value-as-string (merge config {:url url})))
-            conf-js (fn [opts] (str "window.API_CONF = " (config-json opts) ";"))
             options (as-> options $
                           (update $ :root (fnil identity "swagger-ui"))
                           (update $ :url (fnil identity "/swagger.json"))
-                          (assoc $ :paths {"/conf.js" {:headers {"Content-Type" "application/javascript"}
-                                                       :status 200
-                                                       :body (conf-js $)}
-                                           "/config.json" {:headers {"Content-Type" "application/json"}
+                          (assoc $ :paths {"/config.json" {:headers {"Content-Type" "application/json"}
                                                            :status 200
                                                            :body (config-json $)}}))]
         (ring/routes

--- a/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
+++ b/modules/reitit-swagger-ui/src/reitit/swagger_ui.cljc
@@ -15,19 +15,17 @@
      | :config          | parameters passed to swaggger-ui as-is.
 
      See https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md
-     for all available :config options
+     for all available :config options.
 
      Examples:
+     ```
+     (swagger-ui/create-swagger-ui-handler)
 
-        ;; with defaults
-        (create-swagger-ui-handler)
-
-        ;; with path and url set, swagger validator disabled, jsonEditor enabled
-        (swagger-ui/create-swagger-ui-handler
-          {:path \"/\"
-           :url \"/api/swagger.json\"
-           :config {:validatorUrl nil
-                    :jsonEditor true})"
+     (swagger-ui/create-swagger-ui-handler
+       {:path \"/swagger-ui\"
+        :url \"/api/swagger.json\"
+        :config {:validatorUrl nil}})
+     ```"
      ([]
       (create-swagger-ui-handler nil))
      ([options]


### PR DESCRIPTION
1. Removed `conf.js` resource. It is obsolete and not used anymore since [this commit](https://github.com/metosin/ring-swagger-ui/commit/b04bd6bd7459fc9312ae803c1ba4eab668d5de11#diff-1ad9103f97661313bb62105d058035980e03086d9b4d27639cdc4a890c9e33b3)
2. Updated the link to the Swagger UI configuration page.
3. Updated the examples section: [they is not formatted properly](https://cljdoc.org/d/metosin/reitit-swagger-ui/0.5.10/api/reitit.swagger-ui#) in cljdoc so I added ```. Also there is no `jsonEditor` param anymore.
