### PR TITLE
Link to docs for Malli coercion

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -21,6 +21,7 @@
 * [Plumatic Schema](coercion/schema_coercion.md)
 * [Clojure.spec](coercion/clojure_spec_coercion.md)
 * [Data-specs](coercion/data_spec_coercion.md)
+* [Malli](coercion/malli_coercion.md)
 
 ## Ring
 

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -28,7 +28,8 @@
    ["Coercion Explained" {:file "doc/coercion/coercion.md"}]
    ["Plumatic Schema" {:file "doc/coercion/schema_coercion.md"}]
    ["Clojure.spec" {:file "doc/coercion/clojure_spec_coercion.md"}]
-   ["Data-specs" {:file "doc/coercion/data_spec_coercion.md"}]]
+   ["Data-specs" {:file "doc/coercion/data_spec_coercion.md"}]
+   ["Malli" {:file "doc/coercion/malli_coercion.md"}]]
   ["Ring" {}
    ["Ring-router" {:file "doc/ring/ring.md"}]
    ["Reverse-routing" {:file "doc/ring/reverse_routing.md"}]


### PR DESCRIPTION
How to do request coercion with Malli is documented in the doc/ folder, but the docs don't show up on cljdoc. This PR adds a link to the Malli coercion docs so that cljdoc might index those documents.

I haven't been able test cljdoc ingestion locally, so I'd appreciate a second pair of eyes.