### PR TITLE
Use correct keyword to access :query-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A Ring routing app with input & output coercion using [data-specs](https://githu
       ["/api"
        ["/math" {:get {:parameters {:query {:x int?, :y int?}}
                        :responses {200 {:body {:total pos-int?}}}
-                       :handler (fn [{{{:keys [x y]} :query} :parameters}]
+                       :handler (fn [{{:keys [x y]} :query-params}]
                                   {:status 200
                                    :body {:total (+ x y)}})}}]]
       ;; router data effecting all routes


### PR DESCRIPTION
I noticed that the given example does not quite work as it tries to access query parameters from `:parameters` instead of `:query-params`. I was confused about this at first as I'm quite new in the clojure world, but was able to figure out that the query parameters are actually delivered in `:query-params` field.

So just a small fix to the documentation to help fellow newbies to grasp things quicker. :)

Also feel free to decline if you see that the example is actually correct but I have some blanks in my understanding.