### PR TITLE
Fix relative links in documentation

### DIFF
--- a/doc/advanced/different_routers.md
+++ b/doc/advanced/different_routers.md
@@ -1,6 +1,6 @@
 # Different Routers
 
-Reitit ships with several different implementations for the `Router` protocol, originally based on the [Pedestal](https://github.com/pedestal/pedestal/tree/master/route) implementation. `router` function selects the most suitable implementation by inspecting the expanded routes. The implementation can be set manually using `:router` option, see [configuring routers](advanced/configuring_routers.md).
+Reitit ships with several different implementations for the `Router` protocol, originally based on the [Pedestal](https://github.com/pedestal/pedestal/tree/master/route) implementation. `router` function selects the most suitable implementation by inspecting the expanded routes. The implementation can be set manually using `:router` option, see [configuring routers](configuring_routers.md).
 
 | router                        | description |
 | ------------------------------|-------------|

--- a/doc/basics/error_messages.md
+++ b/doc/basics/error_messages.md
@@ -51,4 +51,4 @@ See the [validating route data](route_data_validation.md) page.
 
 ## Runtime Exception
 
-See [Exception Handling with Ring](exceptions.md).
+See [Exception Handling with Ring](../ring/exceptions.md).

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -76,7 +76,7 @@ The routing sample taken from [bide](https://github.com/funcool/bide) README:
     (r/match-by-path routes "/workspace/1/1")))
 ```
 
-Based on the [perf tests](https://github.com/metosin/reitit/tree/master/perf-test/clj/reitit/perf/bide_perf_test.clj), the first (static path) lookup is 300-500x faster and the second (wildcard path) lookup is 18-110x faster that the other tested routing libs (Ataraxy, Bidi, Compojure and Pedestal).
+Based on the [perf tests](https://github.com/metosin/reitit/blob/master/perf-test/clj/reitit/bide_perf_test.clj), the first (static path) lookup is 300-500x faster and the second (wildcard path) lookup is 18-110x faster that the other tested routing libs (Ataraxy, Bidi, Compojure and Pedestal).
 
 But, the example is too simple for any real benchmark. Also, some of the libraries always match on the `:request-method` too and by doing so, do more work than just match by path. Compojure does most work also by invoking the handler.
 
@@ -146,6 +146,6 @@ Few things that have an effect on performance:
 
 * Wildcard-routes are an order of magnitude slower than static routes
 * Conflicting routes are served with LinearRouter, which is the slowest implementation.
-* It's ok to mix non-wildcard, wildcard or even conflicting routes in a same routing tree. Reitit will create an hierarchy of routers to serve all the routes with best possible implementation. 
+* It's ok to mix non-wildcard, wildcard or even conflicting routes in a same routing tree. Reitit will create an hierarchy of routers to serve all the routes with best possible implementation.
 * Move computation from request processing time into creation time, using by compiling [middleware](ring/compiling_middleware.md), [interceptors](http/interceptors.md) and [route data](advanced/configuring_routers.md).
   * Unmounted middleware (or interceptor) is infinitely faster than a mounted one effectively doing nothing.


### PR DESCRIPTION
This PR fixes two broken internal links in the documentation and a link to a source file.

~There's also a broken external link to http://thinkrelevance.com/blog/2013/06/04/clojure-workflow-reloaded. I've notified Cognitect and @stuartsierra; based on their reply we can either replace or remove the link altogether.~

_Update Dec 2, 2020: the article is now accessible again. Thank you @admiralbumblebee!_

I ran the whole `doc/` folder through [`markdown-link-check`](https://github.com/tcort/markdown-link-check) and found no other broken links.