### PR TITLE
Downcase hidden methods in RESTful example

### DIFF
--- a/doc/ring/RESTful_form_methods.md
+++ b/doc/ring/RESTful_form_methods.md
@@ -8,9 +8,10 @@ We can do this with middleware in reitit like this:
 ```clj
 (defn- hidden-method
   [request]
-  (keyword 
-    (or (get-in request [:form-params "_method"])         ;; look for "_method" field in :form-params
-        (get-in request [:multipart-params "_method"])))) ;; or in :multipart-params
+  (keyword
+    (clojure.string/lower-case
+      (or (get-in request [:form-params "_method"])          ;; look for "_method" field in :form-params
+          (get-in request [:multipart-params "_method"]))))) ;; or in :multipart-params
 
 (def wrap-hidden-method
   {:name ::wrap-hidden-method

--- a/doc/ring/RESTful_form_methods.md
+++ b/doc/ring/RESTful_form_methods.md
@@ -8,10 +8,10 @@ We can do this with middleware in reitit like this:
 ```clj
 (defn- hidden-method
   [request]
-  (keyword
-    (clojure.string/lower-case
-      (or (get-in request [:form-params "_method"])          ;; look for "_method" field in :form-params
-          (get-in request [:multipart-params "_method"]))))) ;; or in :multipart-params
+  (some-> (or (get-in request [:form-params "_method"])         ;; look for "_method" field in :form-params
+              (get-in request [:multipart-params "_method"]))   ;; or in :multipart-params
+          clojure.string/lower-case
+          keyword))
 
 (def wrap-hidden-method
   {:name ::wrap-hidden-method


### PR DESCRIPTION
- this documentation is mildly confusing when combined with hiccup's
  `form-to` since hiccup forcibly transforms the method specified in
  its convenience syntax: `(form-to [:delete "/my-url"] ... )` into an
  upper-case string:
  https://github.com/weavejester/hiccup/blob/80e48352dd2bce5277ccdd06334cfb9be915afb4/src/hiccup/form.clj#L130

- it's also common to get an upper-case string from elsewhere so it
  seems best to wrap the hidden `_method` in `lower-case`.