### PR TITLE
Missing curly brace in documentation

### DIFF
--- a/doc/coercion/malli_coercion.md
+++ b/doc/coercion/malli_coercion.md
@@ -13,7 +13,7 @@
                                  :coercion reitit.coercion.malli/coercion
                                  :parameters {:path [:map
                                                      [:company string?]
-                                                     [:user-id int?]]}]
+                                                     [:user-id int?]]}}]
     {:compile coercion/compile-request-coercers}))
 
 (defn match-by-path-and-coerce! [path]


### PR DESCRIPTION
Missing curly brace in documentation - I noticed this while trying the example in REPL