### PR TITLE
Make the not-found-handler fix backwards compatible

### DIFF
--- a/doc/ring/static.md
+++ b/doc/ring/static.md
@@ -52,7 +52,7 @@ A better way to serve files from conflicting paths, e.g. `"/*"`, is to serve the
 | -----------------|-------------|
 | :parameter         | optional name of the wildcard parameter, defaults to unnamed keyword `:`
 | :root              | optional resource root, defaults to `\"public\"`
-| :path              | optional path to mount the handler to. Works only if mounted outside of a router.
+| :path              | path to mount the handler to. Required when mounted outside of a router, does not work inside a router.
 | :loader            | optional class loader to resolve the resources
 | :index-files       | optional vector of index-files to look in a resource directory, defaults to `[\"index.html\"]`
 | :not-found-handler | optional handler function to use if the requested resource is missing (404 Not Found)

--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -195,7 +195,9 @@
                         root "public"
                         index-files ["index.html"]
                         paths (constantly nil)
-                        not-found-handler (constantly {:status 404, :body "", :headers {}})}}]
+                        not-found-handler (if path
+                                            (constantly nil)
+                                            (constantly {:status 404, :body "", :headers {}}))}}]
      (let [options {:root root
                     :loader loader
                     :index-files? false
@@ -239,7 +241,7 @@
      | -------------------|-------------|
      | :parameter         | optional name of the wildcard parameter, defaults to unnamed keyword `:`
      | :root              | optional resource root, defaults to `\"public\"`
-     | :path              | optional path to mount the handler to. Works only if mounted outside of a router.
+     | :path              | path to mount the handler to. Required when mounted outside of a router, does not work inside a router.
      | :loader            | optional class loader to resolve the resources
      | :index-files       | optional vector of index-files to look in a resource directory, defaults to `[\"index.html\"]`
      | :not-found-handler | optional handler function to use if the requested resource is missing (404 Not Found)"
@@ -256,7 +258,7 @@
      | -------------------|-------------|
      | :parameter         | optional name of the wildcard parameter, defaults to unnamed keyword `:`
      | :root              | optional resource root, defaults to `\"public\"`
-     | :path              | optional path to mount the handler to. Works only if mounted outside of a router.
+     | :path              | path to mount the handler to. Required when mounted outside of a router, does not work inside a router.
      | :loader            | optional class loader to resolve the resources
      | :index-files       | optional vector of index-files to look in a resource directory, defaults to `[\"index.html\"]`
      | :not-found-handler | optional handler function to use if the requested resource is missing (404 Not Found)"


### PR DESCRIPTION
PR #471 aimed to fix issue #464. However, the change was slightly backwards-incompatible, since it made the file and resource handlers use the default 404 handler when mounted outside of the router. The previous behavior was to return nil in that case.

This patch restores the previous behavior and clarifies that `:path` option can be used only when the file/resource handler is mounted outside of a router.

I'm not completely sure if the previous behavior is good. Maybe we should make a minor breaking change here instead of fixing this?

---

TODO:

* [x] Update the user guide as well https://cljdoc.org/d/metosin/reitit/0.5.12/doc/ring/static-resources