### PR TITLE
Document serving static resources from the file system

### DIFF
--- a/doc/ring/static.md
+++ b/doc/ring/static.md
@@ -1,8 +1,12 @@
 # Static Resources (Clojure Only)
 
-Static resources can be served using `reitit.ring/create-resource-handler`. It takes optionally an options map and returns a ring handler to serve files from Classpath.
+Static resources can be served by using the following two functions:
 
-There are two options to serve the files.
+* `reitit.ring/create-resource-handler`, which returns a Ring handler that serves files from classpath, and
+* `reitit.ring/create-file-handler`, which returns a Ring handler that servers files from file system
+
+There are two ways to mount the handlers.
+The examples below use `reitit.ring/create-resource-handler`, but `reitit.ring/create-file-handler` works the same way.
 
 ## Internal routes
 
@@ -33,7 +37,9 @@ To serve static files with conflicting routes, e.g. `"/*"`, one needs to disable
 
 ## External routes
 
-A better way to serve files from conflicting paths, e.g. `"/*"`, is to serve them from the default-handler. One can compose multiple default locations using `ring-handler`. This way, they are only served if none of the actual routes have matched.
+A better way to serve files from conflicting paths, e.g. `"/*"`, is to serve them from the default-handler.
+One can compose multiple default locations using `reitit.ring/ring-handler`.
+This way, they are only served if none of the actual routes have matched.
 
 ```clj
 (ring/ring-handler
@@ -46,10 +52,10 @@ A better way to serve files from conflicting paths, e.g. `"/*"`, is to serve the
 
 ## Configuration
 
-`reitit.ring/create-resource-handler` takes optionally an options map to configure how the files are being served.
+`reitit.ring/create-file-handler` and `reitit.ring/create-resource-handler` take optionally an options map to configure how the files are being served.
 
-| key              | description |
-| -----------------|-------------|
+| key                | description |
+| -------------------|-------------|
 | :parameter         | optional name of the wildcard parameter, defaults to unnamed keyword `:`
 | :root              | optional resource root, defaults to `\"public\"`
 | :path              | path to mount the handler to. Required when mounted outside of a router, does not work inside a router.
@@ -58,9 +64,7 @@ A better way to serve files from conflicting paths, e.g. `"/*"`, is to serve the
 | :not-found-handler | optional handler function to use if the requested resource is missing (404 Not Found)
 
 
-
 ### TODO
 
 * support for things like `:cache`, `:etag`, `:last-modified?`, and `:gzip`
 * support for ClojureScript
-* serve from file-system


### PR DESCRIPTION
Noticed that `reitit.ring/create-file-handler` has not been documented in the user guide, so here's a quick stab at it.