### PR TITLE
fix documentation typos

### DIFF
--- a/doc/basics/route_syntax.md
+++ b/doc/basics/route_syntax.md
@@ -132,7 +132,7 @@ Routes are just data, so it's easy to create them programmatically:
 
 ### Explicit path-parameter syntax
 
-Router options `:syntax` allows the path-parameter syntax to be explicitely defined. It takes a keyword or set of keywords as a value. Valid values are `:colon` and `:bracket`. Default value is `#{:colon :bracket}`.
+Router options `:syntax` allows the path-parameter syntax to be explicitly defined. It takes a keyword or set of keywords as a value. Valid values are `:colon` and `:bracket`. Default value is `#{:colon :bracket}`.
 
 With defaults:
 

--- a/doc/basics/router.md
+++ b/doc/basics/router.md
@@ -85,9 +85,10 @@ As routes are defined as plain data, it's easy to merge multiple route trees int
    ["/ping" ::ping]
    ["/db" ::db]])
 
-(r/router
-  [admin-routes
-   user-routes])
+(def router
+  (r/router
+    [admin-routes
+     user-routes]))
 ```
 
 Merged route tree:

--- a/doc/basics/router.md
+++ b/doc/basics/router.md
@@ -109,6 +109,6 @@ When router is created, the following steps are done:
 * route arguments are expanded (via `:expand` option)
 * routes are coerced (via `:coerce` options)
 * route tree is compiled (via `:compile` options)
-* [route conflicts](advanced/route_conflicts.md) are resolved (via `:conflicts` options)
+* [route conflicts](route_conflicts.md) are resolved (via `:conflicts` options)
 * optionally, route data is validated (via `:validate` options)
 * [router implementation](../advanced/different_routers.md) is automatically selected (or forced via `:router` options) and created

--- a/doc/coercion/malli_coercion.md
+++ b/doc/coercion/malli_coercion.md
@@ -49,7 +49,6 @@ Failing coercion:
 Using `create` with options to create the coercion instead of `coercion`:
 
 ```clj
-
 (require '[malli.util :as mu])
 
 (reitit.coercion.malli/create

--- a/doc/coercion/malli_coercion.md
+++ b/doc/coercion/malli_coercion.md
@@ -49,11 +49,14 @@ Failing coercion:
 Using `create` with options to create the coercion instead of `coercion`:
 
 ```clj
+
+(require '[malli.util :as mu])
+
 (reitit.coercion.malli/create
-  {:transformers {:body {:default default-transformer-provider
-                         :formats {"application/json" json-transformer-provider}}
-                  :string {:default string-transformer-provider}
-                  :response {:default default-transformer-provider}}
+  {:transformers {:body {:default reitit.coercion.malli/default-transformer-provider
+                         :formats {"application/json" reitit.coercion.malli/json-transformer-provider}}
+                  :string {:default reitit.coercion.malli/string-transformer-provider}
+                  :response {:default reitit.coercion.malli/default-transformer-provider}}
    ;; set of keys to include in error messages
    :error-keys #{:type :coercion :in :schema :value :errors :humanized #_:transformed}
    ;; schema identity function (default: close all map schemas)


### PR DESCRIPTION
Fixed several typos in the documentation:
- word typos
- a link
- some examples