### PR TITLE
duplicate r/routes output

### DIFF
--- a/doc/basics/router.md
+++ b/doc/basics/router.md
@@ -63,14 +63,6 @@ Route names:
 ; [:user/ping :user/user]
 ```
 
-The compiled route tree:
-
-```clj
-(r/routes router)
-; [["/api/ping" {:name :user/ping} nil]
-;  ["/api/user/:id" {:name :user/user} nil]]
-```
-
 ### Composing
 
 As routes are defined as plain data, it's easy to merge multiple route trees into a single router


### PR DESCRIPTION
Perhaps this is not needed as the same output is shown above close.
Or the `nil`s need to be removed to match actual output. See PR513 https://github.com/metosin/reitit/pull/513