### PR TITLE
Remove unused internal ‘goog-extend’ function

### DIFF
--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -252,15 +252,3 @@
                 (str/join "&" (map query-parameter (repeat k) v))
                 (query-parameter k v))))
        (str/join "&")))
-
-(defmacro goog-extend [type base-type ctor & methods]
-  `(do
-     (def ~type (fn ~@ctor))
-
-     (goog/inherits ~type ~base-type)
-
-     ~@(map
-         (fn [method]
-           `(set! (.. ~type -prototype ~(symbol (str "-" (first method))))
-                  (fn ~@(rest method))))
-         methods)))


### PR DESCRIPTION
This function is internal (meaning in a `*.impl` namespace) and not used anymore.