### PR TITLE
Add support for malli-lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 **[compare](https://github.com/metosin/reitit/compare/0.5.15...master)**
 
-* Support for [Malli Lite Syntax][Lite Syntax](https://github.com/metosin/malli#lite) in coercion (enabled by default):
+* Support for [Malli Lite Syntax](https://github.com/metosin/malli#lite) in coercion (enabled by default):
 
 ```clj
 ["/add/:id" {:post {:parameters {:path {:id int?}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 **[compare](https://github.com/metosin/reitit/compare/0.5.15...master)**
 
+* Support for [Malli Lite Syntax][Lite Syntax](https://github.com/metosin/malli#lite) in coercion (enabled by default):
+
+```clj
+["/add/:id" {:post {:parameters {:path {:id int?}
+                                 :query {:a (l/optional int?)}
+                                 :body {:id int?
+                                        :data {:id (l/maybe int?)
+                                               :orders (l/map-of uuid? {:name string?})}}}
+                    :responses {200 {:body {:total pos-int?}}
+                                500 {:description "fail"}}}}]
+```
+
 * Improved Reitit-frontend function docstrings
 
 * Updated deps:

--- a/doc/coercion/malli_coercion.md
+++ b/doc/coercion/malli_coercion.md
@@ -2,6 +2,10 @@
 
 [Malli](https://github.com/metosin/malli) is data-driven Schema library for Clojure/Script.
 
+## Default Syntax
+
+By default, [Vector Syntax](https://github.com/metosin/malli#vector-syntax) is used:
+
 ```clj
 (require '[reitit.coercion.malli])
 (require '[reitit.coercion :as coercion])
@@ -44,6 +48,20 @@ Failing coercion:
 ; => ExceptionInfo Request coercion failed...
 ```
 
+## Lite Syntax
+
+Same using [Lite Syntax](https://github.com/metosin/malli#lite):
+
+```clj
+(def router
+  (r/router
+    ["/:company/users/:user-id" {:name ::user-view
+                                 :coercion reitit.coercion.malli/coercion
+                                 :parameters {:path {:company string?
+                                                     :user-id int?}}}]
+    {:compile coercion/compile-request-coercers}))
+```
+
 ## Configuring coercion
 
 Using `create` with options to create the coercion instead of `coercion`:
@@ -58,6 +76,8 @@ Using `create` with options to create the coercion instead of `coercion`:
                   :response {:default reitit.coercion.malli/default-transformer-provider}}
    ;; set of keys to include in error messages
    :error-keys #{:type :coercion :in :schema :value :errors :humanized #_:transformed}
+   ;; support lite syntax?
+   :lite true
    ;; schema identity function (default: close all map schemas)
    :compile mu/closed-schema
    ;; validate request & response

--- a/project.clj
+++ b/project.clj
@@ -86,7 +86,7 @@
                                   [metosin/muuntaja "0.6.8"]
                                   [metosin/sieppari "0.0.0-alpha13"]
                                   [metosin/jsonista "0.3.5"]
-                                  [metosin/malli "0.8.1"]
+                                  [metosin/malli "0.8.2-SNAPSHOT"]
                                   [lambdaisland/deep-diff "0.0-47"]
                                   [meta-merge "1.0.0"]
                                   [com.bhauman/spell-spec "0.1.2"]


### PR DESCRIPTION
* Support for [Malli Lite Syntax](https://github.com/metosin/malli#lite) in coercion (enabled by default):

```clj
["/add/:id" {:post {:parameters {:path {:id int?}
                                 :query {:a (l/optional int?)}
                                 :body {:id int?
                                        :data {:id (l/maybe int?)
                                               :orders (l/map-of uuid? {:name string?})}}}
                    :responses {200 {:body {:total pos-int?}}
                                500 {:description "fail"}}}}]
```
