### PR TITLE
Save three seq constructions

### DIFF
--- a/modules/reitit-core/src/reitit/spec.cljc
+++ b/modules/reitit-core/src/reitit/spec.cljc
@@ -122,7 +122,7 @@
   (let [spec (wrap spec)
         spec-explain (fn [[p d _]]
                        (when-let [problems (and spec (s/explain-data spec d))]
-                         (->Problem p nil d spec problems))) h
+                         (->Problem p nil d spec problems)))
         errors (into [] (keep spec-explain) routes)]
     (when (pos? (count errors)) errors)))
 

--- a/modules/reitit-core/src/reitit/spec.cljc
+++ b/modules/reitit-core/src/reitit/spec.cljc
@@ -119,11 +119,12 @@
 (defrecord Problem [path scope data spec problems])
 
 (defn validate-route-data [routes wrap spec]
-  (let [spec (wrap spec)]
-    (some->> (for [[p d _] routes]
-               (when-let [problems (and spec (s/explain-data spec d))]
-                 (->Problem p nil d spec problems)))
-             (keep identity) (seq) (vec))))
+  (let [spec (wrap spec)
+        spec-explain (fn [[p d _]]
+                       (when-let [problems (and spec (s/explain-data spec d))]
+                         (->Problem p nil d spec problems))) h
+        errors (into [] (keep spec-explain) routes)]
+    (when (pos? (count errors)) errors)))
 
 (defn validate [routes {:keys [spec] ::keys [wrap] :or {spec ::default-data, wrap identity}}]
   (when-let [problems (validate-route-data routes wrap spec)]


### PR DESCRIPTION
If this change is interesting, I can also include a similar rewrite of `reitit.ring.spec/validate-route-data`.