### PR TITLE
update jackson-databind for CVE-2020-36518

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,8 +36,8 @@
                          [metosin/malli "0.8.2"]
 
                          ;; https://clojureverse.org/t/depending-on-the-right-versions-of-jackson-libraries/5111
-                         [com.fasterxml.jackson.core/jackson-core "2.13.1"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.13.1"]
+                         [com.fasterxml.jackson.core/jackson-core "2.13.2.1"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.13.2.1"]
 
                          [meta-merge "1.0.0"]
                          [fipp "0.6.25" :exclusions [org.clojure/core.rrb-vector]]

--- a/project.clj
+++ b/project.clj
@@ -36,8 +36,8 @@
                          [metosin/malli "0.8.2"]
 
                          ;; https://clojureverse.org/t/depending-on-the-right-versions-of-jackson-libraries/5111
-                         [com.fasterxml.jackson.core/jackson-core "2.13.2.1"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.13.2.1"]
+                         [com.fasterxml.jackson.core/jackson-core "2.13.2"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.13.2.2"]
 
                          [meta-merge "1.0.0"]
                          [fipp "0.6.25" :exclusions [org.clojure/core.rrb-vector]]


### PR DESCRIPTION
See https://github.com/FasterXML/jackson-databind/issues/2816

See https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.13.2...jackson-databind-2.13.2.2