### PR TITLE
Add support for fragment parameters in the reitit-frontend module

### DIFF
--- a/modules/reitit-core/src/reitit/coercion.cljc
+++ b/modules/reitit-core/src/reitit/coercion.cljc
@@ -39,7 +39,8 @@
    :body (->ParameterCoercion :body-params :body false false)
    :form (->ParameterCoercion :form-params :string true true)
    :header (->ParameterCoercion :headers :string true true)
-   :path (->ParameterCoercion :path-params :string true true)})
+   :path (->ParameterCoercion :path-params :string true true)
+   :fragment (->ParameterCoercion :fragment-params :string true true)})
 
 (defn ^:no-doc request-coercion-failed! [result coercion value in request]
   (throw


### PR DESCRIPTION
Hi there! 

I ran into a problem when developing a `SPA-application` (without backend) that in the `reitit-frontend` is no way to process fragment parameters. I use `supabase`, `google` and `github` as `oauth providers`, which returns response using fragment parameters.

I need to process the fragment parameters due to the fact that the authorization server returns a callback in the following format: https://example.com/#/oauth/google/callback#access_token=foo&refresh_token=bar&provider_token=baz&token_type=bearer&expires_in=3600

This small PR allows us to process fragment parameters the same way we process query parameters.

I created a custom router to implement the required business logic, but I think it will be useful for the community, and that's why I opened this PR.

Links:
- https://www.rfc-editor.org/rfc/rfc6749#section-4.2
- https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2