### PR TITLE
Polish pedestal chains when printing context diffs

### DIFF
--- a/modules/reitit-interceptors/src/reitit/http/interceptors/dev.clj
+++ b/modules/reitit-interceptors/src/reitit/http/interceptors/dev.clj
@@ -20,7 +20,9 @@
 
 (defn- polish [ctx]
   (-> ctx
-      (dissoc ::original ::previous :stack :queue)
+      (dissoc ::original ::previous :stack :queue
+              :io.pedestal.interceptor.chain/stack
+              :io.pedestal.interceptor.chain/queue)
       (update :request dissoc ::r/match ::r/router)))
 
 (defn- handle [name stage]


### PR DESCRIPTION
`print-context-diffs` includes the interceptor stack and queue when using pedestal. remove the pedestal variant of the keys in `polish`.
