### PR TITLE
Upgrade jackson for CVE-2022-42003 and CVE-2022-42004

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,8 +36,8 @@
                          [metosin/malli "0.8.2"]
 
                          ;; https://clojureverse.org/t/depending-on-the-right-versions-of-jackson-libraries/5111
-                         [com.fasterxml.jackson.core/jackson-core "2.13.2"]
-                         [com.fasterxml.jackson.core/jackson-databind "2.13.2.2"]
+                         [com.fasterxml.jackson.core/jackson-core "2.14.1"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.14.1"]
 
                          [meta-merge "1.0.0"]
                          [fipp "0.6.25" :exclusions [org.clojure/core.rrb-vector]]


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42004
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003