### PR TITLE
Fix incorrect ring-router doc references

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -110,9 +110,9 @@ Reverse-routing:
 ;        :path "/api/orders/2"}
 ```
 
-## Ring-router
+## Ring router
 
-Ring-router adds support for `:handler` functions, `:middleware` and routing based on `:request-method`. It also supports pluggable parameter coercion (`clojure.spec`), data-driven middleware, route and middleware compilation, dynamic extensions and more.
+A Ring router function adds support for `:handler` functions, `:middleware` and routing based on `:request-method`. It also supports pluggable parameter coercion (`clojure.spec`), data-driven middleware, route and middleware compilation, dynamic extensions and more.
 
 ```clj
 (require '[reitit.ring :as ring])

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -25,7 +25,7 @@
 
 ## Ring
 
-* [Ring-router](ring/ring.md)
+* [Ring Router](ring/ring.md)
 * [Reverse-routing](ring/reverse_routing.md)
 * [Default handler](ring/default_handler.md)
 * [Slash handler](ring/slash_handler.md)

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -31,7 +31,7 @@
    ["Data-specs" {:file "doc/coercion/data_spec_coercion.md"}]
    ["Malli" {:file "doc/coercion/malli_coercion.md"}]]
   ["Ring" {}
-   ["Ring-router" {:file "doc/ring/ring.md"}]
+   ["Ring Router" {:file "doc/ring/ring.md"}]
    ["Reverse-routing" {:file "doc/ring/reverse_routing.md"}]
    ["Default handler" {:file "doc/ring/default_handler.md"}]
    ["Slash handler" {:file "doc/ring/slash_handler.md"}]

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -114,7 +114,7 @@ A quick poke to [the fast routers in Go](https://github.com/julienschmidt/go-htt
 
 ### Faster!
 
-By default, `reitit.ring/ring-router`, `reitit.http/ring-router` and `reitit.http/routing-interceptor` inject both `Match` and `Router` into the request. You can remove the injections setting options `:inject-match?` and `:inject-router?` to `false`. This saves some tens of nanos (with the hw described above).
+By default, `reitit.ring/router`, `reitit.http/router` and `reitit.http/routing-interceptor` inject both `Match` and `Router` into the request. You can remove the injections setting options `:inject-match?` and `:inject-router?` to `false`. This saves some tens of nanos (with the hw described above).
 
 ```clj
 (require '[reitit.ring :as ring])

--- a/doc/ring/ring.md
+++ b/doc/ring/ring.md
@@ -8,9 +8,9 @@ Read more about the [Ring Concepts](https://github.com/ring-clojure/ring/wiki/Co
 [metosin/reitit-ring "0.5.18"]
 ```
 
-## `reitit.ring/ring-router`
+## `reitit.ring/router`
 
-`ring-router` is a higher order router, which adds support for `:request-method` based routing, [handlers](https://github.com/ring-clojure/ring/wiki/Concepts#handlers) and [middleware](https://github.com/ring-clojure/ring/wiki/Concepts#middleware).
+`reitit.ring/router` is a higher order router, which adds support for `:request-method` based routing, [handlers](https://github.com/ring-clojure/ring/wiki/Concepts#handlers) and [middleware](https://github.com/ring-clojure/ring/wiki/Concepts#middleware).
 
 It accepts the following options:
 
@@ -33,7 +33,7 @@ Example router:
     ["/ping" {:get handler}]))
 ```
 
-Match contains `:result` compiled by the `ring-router`:
+Match contains `:result` compiled by `reitit.ring/router`:
 
 ```clj
 (require '[reitit.core :as r])
@@ -49,7 +49,7 @@ Match contains `:result` compiled by the `ring-router`:
 
 ## `reitit.ring/ring-handler`
 
-Given a `ring-router`, optional default-handler & options, `ring-handler` function will return a valid ring handler supporting both synchronous and [asynchronous](https://www.booleanknot.com/blog/2016/07/15/asynchronous-ring.html) request handling. The following options are available:
+Given a router from `reitit.ring/router`, optional default-handler & options, `ring-handler` function will return a valid ring handler supporting both synchronous and [asynchronous](https://www.booleanknot.com/blog/2016/07/15/asynchronous-ring.html) request handling. The following options are available:
 
 | key               | description |
 | ------------------|-------------|

--- a/doc/ring/swagger.md
+++ b/doc/ring/swagger.md
@@ -6,7 +6,7 @@
 
 Reitit supports [Swagger2](https://swagger.io/) documentation, thanks to [schema-tools](https://github.com/metosin/schema-tools) and [spec-tools](https://github.com/metosin/spec-tools). Documentation is extracted from route definitions, coercion `:parameters` and `:responses` and from a set of new documentation keys.
 
-To enable swagger-documentation for a ring-router:
+To enable swagger-documentation for a Ring router:
 
 1. annotate your routes with swagger-data
 2. mount a swagger-handler to serve the swagger-spec
@@ -129,7 +129,7 @@ Another way to serve the swagger-ui is using the [default handler](default_handl
         ["/pong" {:post (constantly {:status 200, :body "pong"})}]]
        ["/swagger.json"
         {:get {:no-doc true
-               :handler (swagger/create-swagger-handler)}}]]) 
+               :handler (swagger/create-swagger-handler)}}]])
     (swagger-ui/create-swagger-ui-handler {:path "/api-docs"})))
 ```
 

--- a/doc/ring/transforming_middleware_chain.md
+++ b/doc/ring/transforming_middleware_chain.md
@@ -1,6 +1,6 @@
 # Transforming the Middleware Chain
 
-There is an extra option in ring-router (actually, in the underlying middleware-router): `:reitit.middleware/transform` to transform the middleware chain per endpoint. Value should be a function or a vector of functions that get a vector of compiled middleware and should return a new vector of middleware.
+There is an extra option in the Ring router (actually, in the underlying middleware-router): `:reitit.middleware/transform` to transform the middleware chain per endpoint. Value should be a function or a vector of functions that get a vector of compiled middleware and should return a new vector of middleware.
 
 ## Example Application
 
@@ -71,4 +71,3 @@ Using `reitit.ring.middleware.dev/print-request-diffs` transformation, the reque
 Sample output:
 
 ![Ring Request Diff](../images/ring-request-diff.png)
-

--- a/test/cljc/reitit/ring_test.cljc
+++ b/test/cljc/reitit/ring_test.cljc
@@ -38,7 +38,7 @@
             nil
             nil)))))
 
-(deftest ring-router-test
+(deftest router-test
 
   (testing "all paths should have a handler"
     (is (thrown-with-msg?


### PR DESCRIPTION
It looks like documentation references to `ring-router` are left-overs from early README examples - I couldn't find any code that ever used the name. The Ring router named `reitit.ring/router`.

While it didn't take too long for me to realize why my `ring-router` was not working, I had to look the examples to figure out the name of the function was just `router` - which was confusing since the section header stated `reitit-router`.

It would be good to have someone knowledgeable with the docs review for possible breaking urls - specifically, does the change in `doc/cljdoc.edn` affect the generated `.../ring/ring-router` path? A link from `README.md` still references `.../ring/ring-router`.