### PR TITLE
Fix malli swagger defs w/ custom registries

### DIFF
--- a/modules/reitit-malli/src/reitit/coercion/malli.cljc
+++ b/modules/reitit-malli/src/reitit/coercion/malli.cljc
@@ -76,33 +76,6 @@
                 value))))))))
 
 ;;
-;; swagger
-;;
-
-(defmulti extract-parameter (fn [in _ _] in))
-
-(defmethod extract-parameter :body [_ schema options]
-  (let [swagger-schema (swagger/transform schema (merge options {:in :body, :type :parameter}))]
-    [{:in "body"
-      :name (:title swagger-schema "body")
-      :description (:description swagger-schema "")
-      :required (not= :maybe (m/type schema))
-      :schema swagger-schema}]))
-
-(defmethod extract-parameter :default [in schema options]
-  (let [{:keys [properties required]} (swagger/transform schema (merge options {:in in, :type :parameter}))]
-    (mapv
-     (fn [[k {:keys [type] :as schema}]]
-       (merge
-        {:in (name in)
-         :name k
-         :description (:description schema "")
-         :type type
-         :required (contains? (set required) k)}
-        schema))
-     properties)))
-
-;;
 ;; public api
 ;;
 
@@ -145,28 +118,26 @@
      (reify coercion/Coercion
        (-get-name [_] :malli)
        (-get-options [_] opts)
-       (-get-apidocs [_ specification {:keys [parameters responses]}]
+       (-get-apidocs [this specification {:keys [parameters responses]}]
          (case specification
-           :swagger (merge
-                     (if parameters
-                       {:parameters
-                        (->> (for [[in schema] parameters
-                                   parameter (extract-parameter in (compile schema options) options)]
-                               parameter)
-                             (into []))})
-                     (if responses
-                       {:responses
-                        (into
-                         (empty responses)
-                         (for [[status response] responses]
-                           [status (as-> response $
-                                     (set/rename-keys $ {:body :schema})
-                                     (update $ :description (fnil identity ""))
-                                     (if (:schema $)
-                                       (-> $
-                                           (update :schema compile options)
-                                           (update :schema swagger/transform {:type :schema}))
-                                       $))]))}))
+           :swagger (swagger/swagger-spec
+                      (merge
+                        (if parameters
+                          {::swagger/parameters
+                           (into
+                             (empty parameters)
+                             (for [[k v] parameters]
+                               [k (coercion/-compile-model this v nil)]))})
+                        (if responses
+                          {::swagger/responses
+                           (into
+                             (empty responses)
+                             (for [[k response] responses]
+                               [k (as-> response $
+                                        (set/rename-keys $ {:body :schema})
+                                        (if (:schema $)
+                                          (update $ :schema #(coercion/-compile-model this % nil))
+                                          $))]))})))
            (throw
             (ex-info
              (str "Can't produce Schema apidocs for " specification)

--- a/modules/reitit-swagger/src/reitit/swagger.cljc
+++ b/modules/reitit-swagger/src/reitit/swagger.cljc
@@ -102,9 +102,17 @@
                             (if-let [endpoint (some->> c (keep transform-endpoint) (seq) (into {}))]
                               [(swagger-path p (r/options router)) endpoint]))
            map-in-order #(->> % (apply concat) (apply array-map))
-           paths (->> router (r/compiled-routes) (filter accept-route) (map transform-path) map-in-order)]
+           paths (->> router (r/compiled-routes) (filter accept-route) (map transform-path) map-in-order)
+           definitions (reduce-kv
+                         (fn [ds _ v]
+                           (let [ks (keys v)]
+                             (merge ds (apply merge
+                                              (for [k ks]
+                                                (when-let [method-map (get v k)]
+                                                  (:definitions method-map)))))))
+                         {} paths)]
        {:status 200
-        :body (meta-merge swagger {:paths paths})}))
+        :body (meta-merge swagger {:paths paths :definitions definitions})}))
     ([req res raise]
      (try
        (res (create-swagger req))

--- a/test/cljc/reitit/swagger_test.clj
+++ b/test/cljc/reitit/swagger_test.clj
@@ -256,7 +256,6 @@
                                                                      400 {:schema {:type "string"}
                                                                           :description "kosh"}
                                                                      500 {:description "fail"}}
-                                                         :definitions nil
                                                          :summary "plus"}
                                                    :post {:parameters [{:in "body",
                                                                         :name "body",
@@ -281,7 +280,6 @@
                                                                       400 {:schema {:type "string"}
                                                                            :description "kosh"}
                                                                       500 {:description "fail"}}
-                                                          :definitions nil
                                                           :summary "plus with body"}
                                                    :put {:parameters [{:in "body"
                                                                        :name "body"
@@ -290,33 +288,14 @@
                                                                        :schema
                                                                        {:type "object"
                                                                         :additionalProperties
-                                                                        {:$ref "#/definitions/reitit.swagger-test~1req-val"}
-                                                                        :definitions {::req-key
-                                                                                      {:type "string"
-                                                                                       :x-anyOf [{:type "string"}
-                                                                                                 {:type "string"}]}
-                                                                                      ::req-val
-                                                                                      {:type "object"
-                                                                                       :x-anyOf [{:type "object"}
-                                                                                                 {:type "string"}]}}}}]
+                                                                        {:$ref "#/definitions/reitit.swagger-test~1req-val"}}}]
                                                          :responses {200
                                                                      {:schema
                                                                       {:$ref "#/definitions/reitit.swagger-test~1resp-map"
                                                                        :x-anyOf [{:$ref "#/definitions/reitit.swagger-test~1resp-map"}
-                                                                                 {:$ref "#/definitions/reitit.swagger-test~1resp-string"}]
-                                                                       :definitions {::resp-map {:type "object"}
-                                                                                     ::resp-string
-                                                                                     {:type "string", :minLength 1}}}
+                                                                                 {:$ref "#/definitions/reitit.swagger-test~1resp-string"}]}
                                                                       :description ""}
                                                                      500 {:description "fail"}}
-                                                         :definitions {::req-key {:type "string"
-                                                                                  :x-anyOf [{:type "string"}
-                                                                                            {:type "string"}]}
-                                                                       ::req-val {:type "object"
-                                                                                  :x-anyOf [{:type "object"}
-                                                                                            {:type "string"}]}
-                                                                       ::resp-map {:type "object"}
-                                                                       ::resp-string {:type "string", :minLength 1}}
                                                          :summary "plus put with definitions"}}
                             "/api/schema/plus/{z}" {:get {:parameters [{:description ""
                                                                         :format "int32"

--- a/test/cljc/reitit/swagger_test.clj
+++ b/test/cljc/reitit/swagger_test.clj
@@ -138,6 +138,7 @@
           expected {:x-id #{::math}
                     :swagger "2.0"
                     :info {:title "my-api"}
+                    :definitions {}
                     :paths {"/api/spec/plus/{z}" {:patch {:parameters []
                                                           :summary "patch"
                                                           :operationId "Patch"
@@ -223,6 +224,7 @@
                                                                      400 {:schema {:type "string"}
                                                                           :description "kosh"}
                                                                      500 {:description "fail"}}
+                                                         :definitions nil
                                                          :summary "plus"}
                                                    :post {:parameters [{:in "body",
                                                                         :name "body",
@@ -247,6 +249,7 @@
                                                                       400 {:schema {:type "string"}
                                                                            :description "kosh"}
                                                                       500 {:description "fail"}}
+                                                          :definitions nil
                                                           :summary "plus with body"}}
                             "/api/schema/plus/{z}" {:get {:parameters [{:description ""
                                                                         :format "int32"


### PR DESCRIPTION
Fixes #558 

Relies on the changes in https://github.com/metosin/malli/pull/863

Lifts the `definitions` to the root of the `swagger.json` document so that all of the `$ref`s to them can resolve. Also fixes some naming / encoding issues with them and a circular ref problem I was noticing where sometimes a definition would just become a ref to itself.