### PR TITLE
Fix #600: Add frontend function to update query-params for current path

### DIFF
--- a/doc/frontend/browser.md
+++ b/doc/frontend/browser.md
@@ -2,8 +2,16 @@
 
 Reitit includes two browser history integrations.
 
-Functions follow HTML5 History API: `push-state` to change route, `replace-state`
-to change route without leaving previous entry in browser history.
+Main functions are `navigate` and `set-query`. Navigate is used to navigate
+to named routes, and the options parameter can be used to control all
+parameters and if `pushState` or `replaceState` should be used to control
+browser history stack. The `set-query` function can be used to change
+or modify query parameters for the current route, it takes either map of
+new query params or function from old params to the new params.
+
+There are also secondary functions following HTML5 History API:
+`push-state` to navigate to new route adding entry to the history and
+`replace-state` to change route without leaving previous entry in browser history.
 
 ## Fragment router
 

--- a/examples/frontend-controllers/src/frontend/core.cljs
+++ b/examples/frontend-controllers/src/frontend/core.cljs
@@ -19,10 +19,17 @@
      [:ul
       [:li [:a {:href (rfe/href ::item {:id 1})} "Item 1"]]
       [:li [:a {:href (rfe/href ::item {:id 2} {:foo "bar"})} "Item 2"]]]
-     (if id
+     (when id
        [:h2 "Selected item " id])
-     (if (:foo query)
-       [:p "Optional foo query param: " (:foo query)])]))
+     [:p "Query params: " [:pre (pr-str query)]]
+     [:ul
+      [:li [:a {:on-click #(rfe/set-query {:a 1})} "set a=1"]]
+      [:li [:a {:on-click #(rfe/set-query {:a 2} {:replace true})} "set a=2 and replaceState"]]
+      [:li [:a {:on-click (fn [_] (rfe/set-query #(assoc % :foo "zzz")))} "add foo=zzz"]]]
+     [:button
+      {:on-click #(rfe/navigate ::item {:path-params {:id 3}
+                                        :query-params {:foo "aaa"}})}
+      "Navigate example, go to item 3"]]))
 
 (defonce match (r/atom nil))
 
@@ -31,9 +38,8 @@
    [:ul
     [:li [:a {:href (rfe/href ::frontpage)} "Frontpage"]]
     [:li
-     [:a {:href (rfe/href ::item-list)} "Item list"]
-     ]]
-   (if @match
+     [:a {:href (rfe/href ::item-list)} "Item list"]]]
+   (when @match
      (let [view (:view (:data @match))]
        [view @match]))
    [:pre (with-out-str (fedn/pprint @match))]])
@@ -63,7 +69,8 @@
       ["/:id"
        {:name ::item
         :parameters {:path {:id s/Int}
-                     :query {(s/optional-key :foo) s/Keyword}}
+                     :query {(s/optional-key :a) s/Int
+                             (s/optional-key :foo) s/Keyword}}
         :controllers [{:parameters {:path [:id]}
                        :start (fn [{:keys [path]}]
                                 (js/console.log "start" "item controller" (:id path)))

--- a/modules/reitit-frontend/src/reitit/frontend.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend.cljs
@@ -88,3 +88,14 @@
        match)
      (do (js/console.warn "missing route" name)
          nil))))
+
+(defn update-path-query-params
+  "Given Reitit-frontend path, update the query params
+  with given function and arguments.
+
+  NOTE: coercion is not applied to the query params"
+  [path f & args]
+  (let [^goog.Uri uri (Uri/parse path)
+        new-query (apply f (query-params uri) args)]
+    (.setQueryData uri (QueryData/createFromMap (clj->js new-query)))
+    (.toString uri)))

--- a/modules/reitit-frontend/src/reitit/frontend.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend.cljs
@@ -1,11 +1,11 @@
 (ns reitit.frontend
   (:require [clojure.set :as set]
             [reitit.coercion :as coercion]
-            [reitit.core :as r])
-  (:import goog.Uri
-           goog.Uri.QueryData))
+            [reitit.core :as r]
+            goog.Uri
+            goog.Uri.QueryData))
 
-(defn- query-param [^QueryData q k]
+(defn- query-param [^goog.uri.QueryData q k]
   (let [vs (.getValues q k)]
     (if (< (alength vs) 2)
       (aget vs 0)
@@ -13,7 +13,7 @@
 
 (defn query-params
   "Given goog.Uri, read query parameters into a Clojure map."
-  [^Uri uri]
+  [^goog.Uri uri]
   (let [q (.getQueryData uri)]
     (->> q
          (.getKeys)
@@ -26,11 +26,11 @@
 
   Note: coercion is not applied to the query params"
   [path new-query-or-update-fn]
-  (let [^goog.Uri uri (Uri/parse path)
+  (let [^goog.Uri uri (goog.Uri/parse path)
         new-query (if (fn? new-query-or-update-fn)
                     (new-query-or-update-fn (query-params uri))
                     new-query-or-update-fn)]
-    (.setQueryData uri (QueryData/createFromMap (clj->js new-query)))
+    (.setQueryData uri (goog.Uri.QueryData/createFromMap (clj->js new-query)))
     (.toString uri)))
 
 (defn match-by-path
@@ -40,7 +40,7 @@
   :on-coercion-error - a sideeffecting fn of `match exception -> nil`"
   ([router path] (match-by-path router path nil))
   ([router path {:keys [on-coercion-error]}]
-   (let [uri (.parse Uri path)
+   (let [uri (.parse goog.Uri path)
          coerce! (if on-coercion-error
                    (fn [match]
                      (try (coercion/coerce! match)

--- a/modules/reitit-frontend/src/reitit/frontend.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend.cljs
@@ -30,6 +30,9 @@
         new-query (if (fn? new-query-or-update-fn)
                     (new-query-or-update-fn (query-params uri))
                     new-query-or-update-fn)]
+    ;; NOTE: Differences to reitit.impl/query-string?
+    ;; reitit fn adds "=" even if value is empty string
+    ;; reitit encodes " " as "+" while browser and goog.Uri encode as "%20"
     (.setQueryData uri (goog.Uri.QueryData/createFromMap (clj->js new-query)))
     (.toString uri)))
 

--- a/modules/reitit-frontend/src/reitit/frontend/easy.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/easy.cljs
@@ -104,11 +104,13 @@
    (rfh/replace-state @history name path-params query-params)))
 
 (defn update-query
+  ;; TODO: Sync the docstring with other namespaces
   "Takes the current location and updates the query params
   with given fn and arguments."
   [f & args]
   ;; TODO: rfh version?
   (let [current-path (rfh/-get-path @history)
         new-path (apply rf/update-path-query-params current-path f args)]
+    ;; TODO: replaceState version
     (.pushState js/window.history nil "" new-path)
     (rfh/-on-navigate @history new-path)))

--- a/modules/reitit-frontend/src/reitit/frontend/easy.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/easy.cljs
@@ -2,8 +2,7 @@
   "Easy wrapper over reitit.frontend.history,
   handling the state. Only one router can be active
   at a time."
-  (:require [reitit.frontend.history :as rfh]
-            [reitit.frontend :as rf]))
+  (:require [reitit.frontend.history :as rfh]))
 
 (defonce history (atom nil))
 
@@ -103,14 +102,43 @@
   ([name path-params query-params]
    (rfh/replace-state @history name path-params query-params)))
 
-(defn update-query
-  ;; TODO: Sync the docstring with other namespaces
-  "Takes the current location and updates the query params
-  with given fn and arguments."
-  [f & args]
-  ;; TODO: rfh version?
-  (let [current-path (rfh/-get-path @history)
-        new-path (apply rf/update-path-query-params current-path f args)]
-    ;; TODO: replaceState version
-    (.pushState js/window.history nil "" new-path)
-    (rfh/-on-navigate @history new-path)))
+;; This duplicates previous two, but the map parameter will be easier way to
+;; extend the functions, e.g. to work with fragment string. Toggling push vs
+;; replace can be also simpler with a flag.
+;; Navigate and set-query are also similer to react-router API.
+(defn
+  ^{:see-also ["reitit.frontend.history/navigate"]}
+  navigate
+  "Updates the browser location and either pushes new entry to the history stack
+  or replaces the latest entry in the the history stack (controlled by
+  `replace` option) using URL built from a route defined by name given
+  parameters.
+
+  Will also trigger on-navigate callback on Reitit frontend History handler.
+
+  Note: currently collections in query-parameters are encoded as field-value
+  pairs separated by &, i.e. \"?a=1&a=2\", if you want to encode them
+  differently, convert the collections to strings first.
+
+  See also:
+  https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
+  https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState"
+  ([name]
+   (rfh/navigate @history name))
+  ([name {:keys [path-params query-params replace] :as opts}]
+   (rfh/navigate @history name opts)))
+
+(defn
+  ^{:see-also ["reitit.frontend.history/set-query"]}
+  set-query
+  "Update query parameters for the current route.
+
+  New query params can be given as a map, or a function taking
+  the old params and returning the new modified params.
+
+  Note: The query parameter values aren't coereced, so the
+  update fn will see string values for all query params."
+  ([new-query-or-update-fn]
+   (rfh/set-query @history new-query-or-update-fn))
+  ([new-query-or-update-fn {:keys [replace] :as opts}]
+   (rfh/set-query @history new-query-or-update-fn opts)))

--- a/modules/reitit-frontend/src/reitit/frontend/easy.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/easy.cljs
@@ -2,7 +2,8 @@
   "Easy wrapper over reitit.frontend.history,
   handling the state. Only one router can be active
   at a time."
-  (:require [reitit.frontend.history :as rfh]))
+  (:require [reitit.frontend.history :as rfh]
+            [reitit.frontend :as rf]))
 
 (defonce history (atom nil))
 
@@ -101,3 +102,13 @@
    (rfh/replace-state @history name path-params nil))
   ([name path-params query-params]
    (rfh/replace-state @history name path-params query-params)))
+
+(defn update-query
+  "Takes the current location and updates the query params
+  with given fn and arguments."
+  [f & args]
+  ;; TODO: rfh version?
+  (let [current-path (rfh/-get-path @history)
+        new-path (apply rf/update-path-query-params current-path f args)]
+    (.pushState js/window.history nil "" new-path)
+    (rfh/-on-navigate @history new-path)))

--- a/modules/reitit-frontend/src/reitit/frontend/history.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend/history.cljs
@@ -3,8 +3,8 @@
   events."
   (:require [goog.events :as gevents]
             [reitit.core :as reitit]
-            [reitit.frontend :as rf])
-  (:import goog.Uri))
+            [reitit.frontend :as rf]
+            goog.Uri))
 
 (defprotocol History
   (-init [this] "Create event listeners")
@@ -78,7 +78,7 @@
   the page location is updated using History API."
   [router e el uri]
   (let [current-domain (if (exists? js/location)
-                         (.getDomain (.parse Uri js/location)))]
+                         (.getDomain (.parse goog.Uri js/location)))]
     (and (or (and (not (.hasScheme uri)) (not (.hasDomain uri)))
              (= current-domain (.getDomain uri)))
          (not (.-altKey e))
@@ -109,7 +109,7 @@
           ignore-anchor-click (fn [e]
                                 ;; Returns the next matching ancestor of event target
                                 (when-let [el (closest-by-tag (event-target e) "a")]
-                                  (let [uri (.parse Uri (.-href el))]
+                                  (let [uri (.parse goog.Uri (.-href el))]
                                     (when (ignore-anchor-click-predicate router e el uri)
                                       (.preventDefault e)
                                       (let [path (str (.getPath uri)

--- a/test/cljs/reitit/frontend/core_test.cljs
+++ b/test/cljs/reitit/frontend/core_test.cljs
@@ -230,16 +230,16 @@
 
 (deftest update-path-query-params-test
   (is (= "foo?bar=1"
-         (rf/update-path-query-params "foo" #(assoc % :bar 1))))
+         (rf/update-path-query-params "foo" assoc :bar 1)))
 
   (is (= "foo?asd=1&bar=1"
-         (rf/update-path-query-params "foo?asd=1" #(assoc % :bar 1))))
+         (rf/update-path-query-params "foo?asd=1" assoc :bar 1)))
 
   (is (= "foo?bar=1"
-         (rf/update-path-query-params "foo?asd=1&bar=1" #(dissoc % :asd))))
+         (rf/update-path-query-params "foo?asd=1&bar=1" dissoc :asd)))
 
   (is (= "foo"
-         (rf/update-path-query-params "foo?asd=1" #(dissoc % :asd))))
+         (rf/update-path-query-params "foo?asd=1" dissoc :asd)))
 
   (testing "Need to coerce current values manually"
     (is (= "foo?foo=2"

--- a/test/cljs/reitit/frontend/core_test.cljs
+++ b/test/cljs/reitit/frontend/core_test.cljs
@@ -227,3 +227,20 @@
                                           :token_type "bearer"
                                           :expires_in 3600}}})
                (m (rf/match-by-path router "/5?mode=foo#access_token=foo&refresh_token=bar&provider_token=baz&token_type=bearer&expires_in=3600"))))))))
+
+(deftest update-path-query-params-test
+  (is (= "foo?bar=1"
+         (rf/update-path-query-params "foo" #(assoc % :bar 1))))
+
+  (is (= "foo?asd=1&bar=1"
+         (rf/update-path-query-params "foo?asd=1" #(assoc % :bar 1))))
+
+  (is (= "foo?bar=1"
+         (rf/update-path-query-params "foo?asd=1&bar=1" #(dissoc % :asd))))
+
+  (is (= "foo"
+         (rf/update-path-query-params "foo?asd=1" #(dissoc % :asd))))
+
+  (testing "Need to coerce current values manually"
+    (is (= "foo?foo=2"
+           (rf/update-path-query-params "foo?foo=1" update :foo #(inc (js/parseInt %)))))))

--- a/test/cljs/reitit/frontend/core_test.cljs
+++ b/test/cljs/reitit/frontend/core_test.cljs
@@ -232,6 +232,10 @@
   (is (= "foo?bar=1"
          (rf/update-path-query-params "foo" assoc :bar 1)))
 
+  (testing "Keep fragment"
+    (is (= "foo?bar=1&zzz=2#aaa"
+           (rf/update-path-query-params "foo?bar=1#aaa" assoc :zzz 2))))
+
   (is (= "foo?asd=1&bar=1"
          (rf/update-path-query-params "foo?asd=1" assoc :bar 1)))
 


### PR DESCRIPTION
Request for comments.

I'm unsure about the naming still, and I should probably move the code to reitit.frontend.history ns and then just wrap that on easy ns.

Is it a problem that the query params aren't going through coercion? If instead of just adding or removing parts, user wants to update some value, it can be surprising.

TODO:
- [x] Tests
- [x] Use in examples
- [x] Allow use with either push or replaceState