### PR TITLE
fix: openapi malli parameter descriptions

### DIFF
--- a/modules/reitit-malli/src/reitit/coercion/malli.cljc
+++ b/modules/reitit-malli/src/reitit/coercion/malli.cljc
@@ -145,14 +145,14 @@
       (when (seq parameters)
         {:parameters
          (->> (for [[in schema] parameters
-                    :let [{:keys [properties required] :as root} (->schema-object schema {:in in :type :parameter})
+                    :let [{:keys [properties required]} (->schema-object schema {:in in :type :parameter})
                           required? (partial contains? (set required))]
                     [k schema] properties]
                 (merge {:in (name in)
                         :name k
                         :required (required? k)
                         :schema schema}
-                       (select-keys root [:description])))
+                       (select-keys schema [:description])))
               (into []))})
       (when body
         ;; body uses a single schema to describe every :requestBody

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -365,7 +365,7 @@
 
 (deftest all-parameter-types-test
   (doseq [[coercion ->schema]
-          [[#'malli/coercion (fn [nom] [:map {:description (str "description " nom)} [nom :string]])]
+          [[#'malli/coercion (fn [nom] [:map [nom [:string {:description (str "description " nom)}]]])]
            [#'schema/coercion (fn [nom] {nom s/Str})]
            [#'spec/coercion (fn [nom] {nom string?})]]]
     (testing coercion

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -367,7 +367,8 @@
   (doseq [[coercion ->schema]
           [[#'malli/coercion (fn [nom] [:map [nom [:string {:description (str "description " nom)}]]])]
            [#'schema/coercion (fn [nom] {nom s/Str})]
-           [#'spec/coercion (fn [nom] {nom string?})]]]
+           [#'spec/coercion (fn [nom] {nom (st/spec {:spec string?
+                                                     :description (str "description " nom)})})]]]
     (testing coercion
       (let [app (ring/ring-handler
                  (ring/router
@@ -395,28 +396,28 @@
           (is (match? [{:in "query"
                         :name "q"
                         :required true
-                        :description (if (= #'malli/coercion coercion)
+                        :description (if (not= #'schema/coercion coercion)
                                        "description :q"
                                        "")
                         :schema {:type "string"}}
                        {:in "header"
                         :name "h"
                         :required true
-                        :description (if (= #'malli/coercion coercion)
+                        :description (if (not= #'schema/coercion coercion)
                                        "description :h"
                                        "")
                         :schema {:type "string"}}
                        {:in "cookie"
                         :name "c"
                         :required true
-                        :description (if (= #'malli/coercion coercion)
+                        :description (if (not= #'schema/coercion coercion)
                                        "description :c"
                                        "")
                         :schema {:type "string"}}
                        {:in "path"
                         :name "p"
                         :required true
-                        :description (if (= #'malli/coercion coercion)
+                        :description (if (not= #'schema/coercion coercion)
                                        "description :p"
                                        "")
                         :schema {:type "string"}}]

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -365,7 +365,7 @@
 
 (deftest all-parameter-types-test
   (doseq [[coercion ->schema]
-          [[#'malli/coercion (fn [nom] [:map [nom :string]])]
+          [[#'malli/coercion (fn [nom] [:map {:description (str "description " nom)} [nom :string]])]
            [#'schema/coercion (fn [nom] {nom s/Str})]
            [#'spec/coercion (fn [nom] {nom string?})]]]
     (testing coercion
@@ -395,18 +395,30 @@
           (is (match? [{:in "query"
                         :name "q"
                         :required true
+                        :description (if (= #'malli/coercion coercion)
+                                       "description :q"
+                                       "")
                         :schema {:type "string"}}
                        {:in "header"
                         :name "h"
                         :required true
+                        :description (if (= #'malli/coercion coercion)
+                                       "description :h"
+                                       "")
                         :schema {:type "string"}}
                        {:in "cookie"
                         :name "c"
                         :required true
+                        :description (if (= #'malli/coercion coercion)
+                                       "description :c"
+                                       "")
                         :schema {:type "string"}}
                        {:in "path"
                         :name "p"
                         :required true
+                        :description (if (= #'malli/coercion coercion)
+                                       "description :p"
+                                       "")
                         :schema {:type "string"}}]
                  (-> spec
                      (get-in [:paths "/parameters" :post :parameters])


### PR DESCRIPTION
... should come from the parameter type, not from the parent :map

for #612