### PR TITLE
Introduce two-phase Schema compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 [breakver]: https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md
 
-## UNREALEASED
+## UNRELEASED
+
+**BREAKING**: `compile-request-coercers` returns a map with `:data` and `:coerce` instead of plain `:coerce` function
+**BREAKING**: Parameter and Response schemas are acculated into vector in route data - to be merged properly into compiled result, fixes [#422](https://github.com/metosin/reitit/issues/422) - works will all of `Malli`, `Schema` and `Spec`.
 
 ```clojure
 [metosin/schema-tools "0.13.1"] is available but we use "0.13.0"
@@ -20,11 +23,11 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 [com.fasterxml.jackson.core/jackson-databind "2.15.1"] is available but we use "2.14.2"
 ```
 
-## 0.7.3-alpha4 (2023-05-17)
+## 0.7.0-alpha4 (2023-05-17)
 
 * OpenAPI 3 parameter descriptions get populated from malli/spec/schema descriptions. [#612](https://github.com/metosin/reitit/issues/612)
 
-## 0.7.3-alpha3 (2023-05-05)
+## 0.7.0-alpha3 (2023-05-05)
 
 * Compile `reitit.Trie` with Java 1.8 target for compatibility
 

--- a/doc/advanced/configuring_routers.md
+++ b/doc/advanced/configuring_routers.md
@@ -11,9 +11,9 @@ Routers can be configured via options. The following options are available for t
 | `:syntax`     | Path-parameter syntax as keyword or set of keywords (default #{:bracket :colon})
 | `:expand`     | Function of `arg opts => data` to expand route arg to route data (default `reitit.core/expand`)
 | `:coerce`     | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
-| `:meta-merge` | Function which follows the signature of `meta-merge.core/meta-merge`, useful for when you want to have more control over the meta merging
 | `:compile`    | Function of `route opts => result` to compile a route handler
 | `:validate`   | Function of `routes opts => ()` to validate route (data) via side-effects
 | `:conflicts`  | Function of `{route #{route}} => ()` to handle conflicting routes
 | `:exception`  | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
+| `:meta-merge` | Function of `left right => merged` to merge route-data (default `meta-merge.core/meta-merge`)
 | `:router`     | Function of `routes opts => router` to override the actual router implementation

--- a/doc/advanced/configuring_routers.md
+++ b/doc/advanced/configuring_routers.md
@@ -2,18 +2,21 @@
 
 Routers can be configured via options. The following options are available for the `reitit.core/router`:
 
-| key           | description
-|---------------|-------------
-| `:path`       | Base-path for routes
-| `:routes`     | Initial resolved routes (default `[]`)
-| `:data`       | Initial route data (default `{}`)
-| `:spec`       | clojure.spec definition for a route data, see `reitit.spec` on how to use this
-| `:syntax`     | Path-parameter syntax as keyword or set of keywords (default #{:bracket :colon})
-| `:expand`     | Function of `arg opts => data` to expand route arg to route data (default `reitit.core/expand`)
-| `:coerce`     | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
-| `:compile`    | Function of `route opts => result` to compile a route handler
-| `:validate`   | Function of `routes opts => ()` to validate route (data) via side-effects
-| `:conflicts`  | Function of `{route #{route}} => ()` to handle conflicting routes
-| `:exception`  | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
-| `:meta-merge` | Function of `left right => merged` to merge route-data (default `meta-merge.core/meta-merge`)
-| `:router`     | Function of `routes opts => router` to override the actual router implementation
+| key             | description
+|-----------------|-------------
+| `:path`         | Base-path for routes
+| `:routes`       | Initial resolved routes (default `[]`)
+| `:data`         | Initial route data (default `{}`)
+| `:spec`         | clojure.spec definition for a route data, see `reitit.spec` on how to use this
+| `:syntax`       | Path-parameter syntax as keyword or set of keywords (default #{:bracket :colon})
+| `:expand`       | Function of `arg opts => data` to expand route arg to route data (default `reitit.core/expand`)
+| `:coerce`       | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
+| `:compile`      | Function of `route opts => result` to compile a route handler
+| `:validate`     | Function of `routes opts => ()` to validate route (data) via side-effects
+| `:conflicts`    | Function of `{route #{route}} => ()` to handle conflicting routes
+| `:exception`    | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
+| `:meta-merge`   | Function of `left right => merged` to merge route-data (default `meta-merge.core/meta-merge`)
+| `:update-paths` | Sequence of Vectors with elements `update-path` and `function`, used to preprocess route data
+| `:router`       | Function of `routes opts => router` to override the actual router implementation
+
+

--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -307,6 +307,7 @@
    :coerce (fn coerce [route _] route)
    :compile (fn compile [[_ {:keys [handler]}] _] handler)
    :exception exception/exception
+   :update-paths [[[:parameters any?] impl/accumulate]]
    :conflicts (fn throw! [conflicts] (exception/fail! :path-conflicts conflicts))})
 
 (defn router
@@ -314,21 +315,22 @@
   Selects implementation based on route details. The following options
   are available:
 
-  | key           | description
-  | --------------|-------------
-  | `:path`       | Base-path for routes
-  | `:routes`     | Initial resolved routes (default `[]`)
-  | `:data`       | Initial route data (default `{}`)
-  | `:spec`       | clojure.spec definition for a route data, see `reitit.spec` on how to use this
-  | `:syntax`     | Path-parameter syntax as keyword or set of keywords (default #{:bracket :colon})
-  | `:expand`     | Function of `arg opts => data` to expand route arg to route data (default `reitit.core/expand`)
-  | `:coerce`     | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
-  | `:compile`    | Function of `route opts => result` to compile a route handler
-  | `:validate`   | Function of `routes opts => ()` to validate route (data) via side-effects
-  | `:conflicts`  | Function of `{route #{route}} => ()` to handle conflicting routes
-  | `:exception`  | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
-  | `:meta-merge` | Function of `left right => merged` to merge route-data (default `meta-merge.core/meta-merge`)
-  | `:router`     | Function of `routes opts => router` to override the actual router implementation"
+  | key             | description
+  | ----------------|-------------
+  | `:path`         | Base-path for routes
+  | `:routes`       | Initial resolved routes (default `[]`)
+  | `:data`         | Initial route data (default `{}`)
+  | `:spec`         | clojure.spec definition for a route data, see `reitit.spec` on how to use this
+  | `:syntax`       | Path-parameter syntax as keyword or set of keywords (default #{:bracket :colon})
+  | `:expand`       | Function of `arg opts => data` to expand route arg to route data (default `reitit.core/expand`)
+  | `:coerce`       | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
+  | `:compile`      | Function of `route opts => result` to compile a route handler
+  | `:validate`     | Function of `routes opts => ()` to validate route (data) via side-effects
+  | `:conflicts`    | Function of `{route #{route}} => ()` to handle conflicting routes
+  | `:exception`    | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
+  | `:meta-merge`   | Function of `left right => merged` to merge route-data (default `meta-merge.core/meta-merge`)
+  | `:update-paths` | Sequence of Vectors with elements `update-path` and `function`, used to preprocess route data
+  | `:router`       | Function of `routes opts => router` to override the actual router implementation"
   ([raw-routes]
    (router raw-routes {}))
   ([raw-routes opts]

--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -314,20 +314,21 @@
   Selects implementation based on route details. The following options
   are available:
 
-  | key          | description
-  | -------------|-------------
-  | `:path`      | Base-path for routes
-  | `:routes`    | Initial resolved routes (default `[]`)
-  | `:data`      | Initial route data (default `{}`)
-  | `:spec`      | clojure.spec definition for a route data, see `reitit.spec` on how to use this
-  | `:syntax`    | Path-parameter syntax as keyword or set of keywords (default #{:bracket :colon})
-  | `:expand`    | Function of `arg opts => data` to expand route arg to route data (default `reitit.core/expand`)
-  | `:coerce`    | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
-  | `:compile`   | Function of `route opts => result` to compile a route handler
-  | `:validate`  | Function of `routes opts => ()` to validate route (data) via side-effects
-  | `:conflicts` | Function of `{route #{route}} => ()` to handle conflicting routes
-  | `:exception` | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
-  | `:router`    | Function of `routes opts => router` to override the actual router implementation"
+  | key           | description
+  | --------------|-------------
+  | `:path`       | Base-path for routes
+  | `:routes`     | Initial resolved routes (default `[]`)
+  | `:data`       | Initial route data (default `{}`)
+  | `:spec`       | clojure.spec definition for a route data, see `reitit.spec` on how to use this
+  | `:syntax`     | Path-parameter syntax as keyword or set of keywords (default #{:bracket :colon})
+  | `:expand`     | Function of `arg opts => data` to expand route arg to route data (default `reitit.core/expand`)
+  | `:coerce`     | Function of `route opts => route` to coerce resolved route, can throw or return `nil`
+  | `:compile`    | Function of `route opts => result` to compile a route handler
+  | `:validate`   | Function of `routes opts => ()` to validate route (data) via side-effects
+  | `:conflicts`  | Function of `{route #{route}} => ()` to handle conflicting routes
+  | `:exception`  | Function of `Exception => Exception ` to handle creation time exceptions (default `reitit.exception/exception`)
+  | `:meta-merge` | Function of `left right => merged` to merge route-data (default `meta-merge.core/meta-merge`)
+  | `:router`     | Function of `routes opts => router` to override the actual router implementation"
   ([raw-routes]
    (router raw-routes {}))
   ([raw-routes opts]

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -105,8 +105,10 @@
 (defn map-data [f routes]
   (mapv (fn [[p ds]] [p (f p ds)]) routes))
 
-(defn meta-merge [left right opts]
-  ((or (:meta-merge opts) mm/meta-merge) left right))
+(defn meta-merge [left right {:keys [meta-merge update-paths]}]
+  (let [update (if update-paths #(path-update % update-paths) identity)
+        merge (or meta-merge mm/meta-merge)]
+    (merge (update left) (update right))))
 
 (defn merge-data [opts p x]
   (reduce

--- a/modules/reitit-core/src/reitit/impl.cljc
+++ b/modules/reitit-core/src/reitit/impl.cljc
@@ -9,6 +9,51 @@
      (:import (java.net URLEncoder URLDecoder)
               (java.util HashMap Map))))
 
+;;
+;; path-update
+;;
+
+(defn -match [path path-map]
+  (letfn [(match [x f] (if (fn? f) (f x) (= x f)))]
+    (reduce
+     (fn [_ [ps f]]
+       (let [match (loop [[p & pr] path, [pp & ppr] ps]
+                     (cond (and p pp (match p pp)) (recur pr ppr)
+                           (= nil p pp) true))]
+         (when match (reduced f))))
+     nil path-map)))
+
+(defn -path-vals [m path-map]
+  (letfn [(-path-vals [l p m]
+            (reduce
+             (fn [l [k v]]
+               (let [p' (conj p k)
+                     f (-match p' path-map)]
+                 (cond
+                   f (cons [p' (f v)] l)
+                   (and (map? v) (seq v)) (-path-vals l p' v)
+                   :else (cons [p' v] l))))
+             l m))]
+    (reverse (-path-vals [] [] m))))
+
+(defn -assoc-in-path-vals [c]
+  (reduce (partial apply assoc-in) {} c))
+
+(defn path-update [m path-map]
+  (-> (-path-vals m path-map)
+      (-assoc-in-path-vals)))
+
+(defn accumulator? [x]
+  (-> x meta ::accumulator))
+
+(defn accumulate
+  ([x] (if-not (accumulator? x) (with-meta [x] {::accumulator true}) x))
+  ([x y] (into (accumulate x) y)))
+
+;;
+;; impl
+;;
+
 (defn parse [path opts]
   (let [path #?(:clj (.intern ^String (trie/normalize path opts)) :cljs (trie/normalize path opts))
         path-parts (trie/split-path path opts)

--- a/modules/reitit-frontend/src/reitit/frontend.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend.cljs
@@ -67,8 +67,8 @@
              fragment (when (.hasFragment uri)
                         (.getFragment uri))
              match (assoc match
-                          :query-params q
-                          :fragment fragment)
+                     :query-params q
+                     :fragment fragment)
              ;; Return uncoerced values if coercion is not enabled - so
              ;; that tha parameters are always accessible from same property.
              parameters (or (coerce! match)

--- a/modules/reitit-http/src/reitit/http.cljc
+++ b/modules/reitit-http/src/reitit/http.cljc
@@ -22,11 +22,12 @@
         compile (fn [[path data] opts scope]
                   (interceptor/compile-result [path data] opts scope))
         ->endpoint (fn [p d m s]
-                     (let [compiled (compile [p d] opts s)]
-                       (-> compiled
-                           (map->Endpoint)
-                           (assoc :path p)
-                           (assoc :method m))))
+                     (let [d (ring/-compile-coercion d)]
+                       (let [compiled (compile [p d] opts s)]
+                         (-> compiled
+                             (map->Endpoint)
+                             (assoc :path p)
+                             (assoc :method m)))))
         ->methods (fn [any? data]
                     (reduce
                      (fn [acc method]
@@ -67,6 +68,7 @@
   ([data opts]
    (let [opts (merge {:coerce coerce-handler
                       :compile compile-result
+                      :update-paths (ring/-update-paths impl/accumulate)
                       ::default-options-endpoint ring/default-options-endpoint} opts)]
      (when (contains? opts ::default-options-handler)
        (ex/fail! (str "Option :reitit.http/default-options-handler is deprecated."

--- a/modules/reitit-spec/src/reitit/coercion/spec.cljc
+++ b/modules/reitit-spec/src/reitit/coercion/spec.cljc
@@ -1,7 +1,9 @@
 (ns reitit.coercion.spec
   (:require [clojure.set :as set]
             [clojure.spec.alpha :as s]
+            [meta-merge.core :as mm]
             [reitit.coercion :as coercion]
+            [reitit.exception :as ex]
             [spec-tools.core :as st #?@(:cljs [:refer [Spec]])]
             [spec-tools.data-spec :as ds #?@(:cljs [:refer [Maybe]])]
             [spec-tools.openapi.core :as openapi]
@@ -66,7 +68,7 @@
     (st/create-spec {:spec this}))
 
   nil
-  (into-spec [this _]))
+  (into-spec [_ _]))
 
 (defn stringify-pred [pred]
   (str (if (seq? pred) (seq pred) pred)))
@@ -92,44 +94,30 @@
         :swagger (swagger/swagger-spec
                   (merge
                    (if parameters
-                     {::swagger/parameters
-                      (into
-                       (empty parameters)
-                       (for [[k v] parameters]
-                         [k (coercion/-compile-model this v nil)]))})
+                     {::swagger/parameters parameters})
                    (if responses
                      {::swagger/responses
                       (into
                        (empty responses)
                        (for [[k response] responses]
                          [k (as-> response $
-                              (set/rename-keys $ {:body :schema})
-                              (if (:schema $)
-                                (update $ :schema #(coercion/-compile-model this % nil))
-                                $))]))})))
+                              (set/rename-keys $ {:body :schema}))]))})))
         :openapi (merge
                   (when (seq (dissoc parameters :body :request :multipart))
-                    (openapi/openapi-spec {::openapi/parameters
-                                           (into (empty parameters)
-                                                 (for [[k v] (dissoc parameters :body :request)]
-                                                   [k (coercion/-compile-model this v nil)]))}))
+                    (openapi/openapi-spec {::openapi/parameters (dissoc parameters :body :request)}))
                   (when (:body parameters)
                     {:requestBody (openapi/openapi-spec
-                                   {::openapi/content (zipmap content-types (repeat (coercion/-compile-model this (:body parameters) nil)))})})
+                                   {::openapi/content (zipmap content-types (repeat (:body parameters)))})})
                   (when (:request parameters)
                     {:requestBody (openapi/openapi-spec
                                    {::openapi/content (merge
                                                        (when-let [default (get-in parameters [:request :body])]
-                                                         (zipmap content-types (repeat (coercion/-compile-model this default nil))))
-                                                       (into {}
-                                                             (for [[format model] (:content (:request parameters))]
-                                                               [format (coercion/-compile-model this model nil)])))})})
+                                                         (zipmap content-types (repeat default)))
+                                                       (:content (:request parameters)))})})
                   (when (:multipart parameters)
-                       {:requestBody
-                        (openapi/openapi-spec
-                         {::openapi/content
-                          {"multipart/form-data"
-                           (coercion/-compile-model this (:multipart parameters) nil)}})})
+                    {:requestBody
+                     (openapi/openapi-spec
+                      {::openapi/content {"multipart/form-data" (:multipart parameters)}})})
                   (when responses
                     {:responses
                      (into
@@ -141,26 +129,33 @@
                               (openapi/openapi-spec
                                {::openapi/content (merge
                                                    (when body
-                                                     (zipmap content-types (repeat (coercion/-compile-model this (:body response) nil))))
+                                                     (zipmap content-types (repeat (:body response))))
                                                    (when response
-                                                     (into {}
-                                                           (for [[format model] (:content response)]
-                                                             [format (coercion/-compile-model this model nil)]))))})))]))}))
+                                                     (:content response)))})))]))}))
         (throw
          (ex-info
           (str "Can't produce Spec apidocs for " specification)
           {:specification specification, :coercion :spec}))))
     (-compile-model [_ model name]
-      (into-spec model name))
+      (into-spec
+       (cond
+         ;; we are safe!
+         (= (count model) 1) (first model)
+         ;; here be dragons, best effort
+         (every? map? model) (apply mm/meta-merge model)
+         ;; not sure if this is what we want
+         (every? s/spec? model) (reduce (fn [acc s] (st/merge acc s)) model)
+         ;; fail fast
+         :else (ex/fail! ::model-error {:message "Can't merge nested data-specs & specs together", :spec model}))
+       name))
     (-open-model [_ spec] spec)
     (-encode-error [_ error]
       (let [problems (-> error :problems ::s/problems)]
         (-> error
             (update :spec (comp str s/form))
             (assoc :problems (mapv #(update % :pred stringify-pred) problems)))))
-    (-request-coercer [this type spec]
-      (let [spec (coercion/-compile-model this spec nil)
-            {:keys [formats default]} (transformers type)]
+    (-request-coercer [_ type spec]
+      (let [{:keys [formats default]} (transformers type)]
         (fn [value format]
           (if-let [transformer (or (get formats format) default)]
             (let [coerced (st/coerce spec value transformer)]

--- a/test/cljc/ctrl/apply.cljc
+++ b/test/cljc/ctrl/apply.cljc
@@ -1,0 +1,35 @@
+(ns ctrl.apply
+  (:refer-clojure :exclude [apply])
+  (:require [clojure.core :as c]))
+
+(defn -match [path path-map]
+  (letfn [(match [x f] (if (fn? f) (f x) (= x f)))]
+    (reduce
+     (fn [_ [ps f]]
+       (let [match (loop [[p & pr] path, [pp & ppr] ps]
+                     (cond (and p pp (match p pp)) (recur pr ppr)
+                           (= nil p pp) true))]
+         (when match (reduced f))))
+     nil path-map)))
+
+(defn -path-vals [m path-map]
+  (letfn [(-path-vals [l p m]
+            (reduce
+             (fn [l [k v]]
+               (let [p' (conj p k)
+                     f (-match p' path-map)]
+                 (cond
+                   f (cons [p' (f v)] l)
+                   (map? v) (-path-vals l p' v)
+                   :else (cons [p' v] l))))
+             l m))]
+    (-path-vals [] [] m)))
+
+(defn -assoc-in-path-vals [c]
+  (reduce (partial c/apply assoc-in) {} c))
+
+(defn any [_] true)
+
+(defn apply [m path-map]
+  (-> (-path-vals m path-map)
+      (-assoc-in-path-vals)))

--- a/test/cljc/ctrl/demo.cljc
+++ b/test/cljc/ctrl/demo.cljc
@@ -1,0 +1,53 @@
+(ns ctrl.demo
+  (:require [reitit.core :as r]
+            [reitit.ring :as ring]
+            [ctrl.merge :as cm]
+            [ctrl.apply :as ca]))
+
+(-> (ring/router
+     ["/api" {:parameters {:header [:map ["Api" :string]]}}
+      ["/math/:x" {:parameters {:path [:map [:x :int]]
+                                :query [:map [:b :string]]
+                                :header [:map ["Math" :string]]}
+                   :responses {200 {:body [:map [:total :int]]}
+                               500 {:description "fail"}}}
+       ["/plus/:y" {:get {:parameters {:query ^:replace [:map [:a :int]]
+                                       :body [:map [:b :int]]
+                                       :header [:map ["Plus" :string]]
+                                       :path [:map [:y :int]]}
+                          :responses {200 {:body [:map [:total2 :int]]}
+                                      500 {:description "fail"}}
+                          :handler (constantly {:status 200, :body "ok"})}}]]])
+    (ring/ring-handler)
+    (ring/get-router)
+    (r/compiled-routes)
+    (last)
+    (last)
+    :get
+    :data)
+
+(def path-map [[[:parameters any?] vector]
+               [[any? :parameters any?] vector]
+               [[:responses any? :body] vector]
+               [[any? :responses any? :body] vector]])
+
+;; using apply as pre-merge
+(cm/merge
+ (ca/apply
+  {:parameters {:query [:map [:x :int]]}
+   :get {:parameters {:query [:map [:x :int]]}
+         :responses {200 {:body [:map [:total :int]]}}}}
+  path-map)
+ (ca/apply
+  {:parameters {:query [:map [:y :int]]}
+   :get {:parameters {:query [:map [:y :int]]}
+         :responses {200 {:body [:map [:total :int]]}}}
+   :post {:parameters {:query [:map [:y :int]]}}}
+  path-map))
+;{:get {:responses {200 {:body [[:map [:total :int]]
+;                               [:map [:total :int]]]}},
+;       :parameters {:query [[:map [:x :int]]
+;                            [:map [:y :int]]]}},
+; :parameters {:query [[:map [:x :int]]
+;                      [:map [:y :int]]]},
+; :post {:parameters {:query [[:map [:y :int]]]}}}

--- a/test/cljc/reitit/coercion_test.cljc
+++ b/test/cljc/reitit/coercion_test.cljc
@@ -14,27 +14,28 @@
 (deftest coercion-test
   (let [r (r/router
            [["/schema" {:coercion reitit.coercion.schema/coercion}
-             ["/:number/:keyword" {:parameters {:path {:number s/Int
-                                                       :keyword s/Keyword}
-                                                :query (s/maybe {:int s/Int, :ints [s/Int], :map {s/Int s/Int}})}}]]
+             ["/:number" {:parameters {:path {:number s/Int}}}
+              ["/:keyword" {:parameters {:path {:keyword s/Keyword}
+                                         :query (s/maybe {:int s/Int, :ints [s/Int], :map {s/Int s/Int}})}}]]]
             ["/malli" {:coercion reitit.coercion.malli/coercion}
-             ["/:number/:keyword" {:parameters {:path [:map [:number int?] [:keyword keyword?]]
-                                                :query [:maybe [:map [:int int?]
-                                                                [:ints [:vector int?]]
-                                                                [:map [:map-of int? int?]]]]}}]]
+             ["/:number" {:parameters {:path [:map [:number int?]]}}
+              ["/:keyword" {:parameters {:path [:map [:keyword keyword?]]
+                                         :query [:maybe [:map [:int int?]
+                                                         [:ints [:vector int?]]
+                                                         [:map [:map-of int? int?]]]]}}]]]
             ["/malli-lite" {:coercion reitit.coercion.malli/coercion}
-             ["/:number/:keyword" {:parameters {:path {:number int?
-                                                       :keyword keyword?}
-                                                :query (l/maybe {:int int?
-                                                                 :ints (l/vector int?)
-                                                                 :map (l/map-of int? int?)})}}]]
+             ["/:number" {:parameters {:path {:number int?}}}
+              ["/:keyword" {:parameters {:path {:keyword keyword?}
+                                         :query (l/maybe {:int int?
+                                                          :ints (l/vector int?)
+                                                          :map (l/map-of int? int?)})}}]]]
             ["/spec" {:coercion reitit.coercion.spec/coercion}
-             ["/:number/:keyword" {:parameters {:path {:number int?
-                                                       :keyword keyword?}
-                                                :query (ds/maybe {:int int?, :ints [int?], :map {int? int?}})}}]]
+             ["/:number" {:parameters {:path {:number int?}}}
+              ["/:keyword" {:parameters {:path {:keyword keyword?}
+                                         :query (ds/maybe {:int int?, :ints [int?], :map {int? int?}})}}]]]
             ["/none"
-             ["/:number/:keyword" {:parameters {:path {:number int?
-                                                       :keyword keyword?}}}]]]
+             ["/:number" {:parameters {:path {:number int?}}}
+              ["/:keyword" {:parameters {:path {:keyword keyword?}}}]]]]
            {:compile coercion/compile-request-coercers})]
 
     (testing "schema-coercion"

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -267,14 +267,14 @@
     (let [pong (constantly "ok")
           routes ["/api" {:mw [:api]}
                   ["/ping" :kikka]
-                  ["/user/:id" {:parameters {:id "String"}}
-                   ["/:sub-id" {:parameters {:sub-id "String"}}]]
+                  ["/user/:id" {:parameters {:path {:id :string}}}
+                   ["/:sub-id" {:parameters {:path {:sub-id :string}}}]]
                   ["/pong" pong]
                   ["/admin" {:mw [:admin] :roles #{:admin}}
                    ["/user" {:roles ^:replace #{:user}}]
                    ["/db" {:mw [:db]}]]]
           expected [["/api/ping" {:mw [:api], :name :kikka}]
-                    ["/api/user/:id/:sub-id" {:mw [:api], :parameters {:id "String", :sub-id "String"}}]
+                    ["/api/user/:id/:sub-id" {:mw [:api], :parameters {:path [{:id :string} {:sub-id :string}]}}]
                     ["/api/pong" {:mw [:api], :handler pong}]
                     ["/api/admin/user" {:mw [:api :admin], :roles #{:user}}]
                     ["/api/admin/db" {:mw [:api :admin :db], :roles #{:admin}}]]
@@ -282,7 +282,7 @@
       (is (= expected (impl/resolve-routes routes (r/default-router-options))))
       (is (= (r/map->Match
               {:template "/api/user/:id/:sub-id"
-               :data {:mw [:api], :parameters {:id "String", :sub-id "String"}}
+               :data {:mw [:api], :parameters {:path [{:id :string} {:sub-id :string}]}}
                :path "/api/user/1/2"
                :path-params {:id "1", :sub-id "2"}})
              (r/match-by-path router "/api/user/1/2"))))))

--- a/test/cljc/reitit/impl_test.cljc
+++ b/test/cljc/reitit/impl_test.cljc
@@ -171,3 +171,18 @@
           :path-parts ["https://google.com"]
           :path-params #{}}
          (impl/parse "https://google.com" nil))))
+
+(deftest path-update-test
+  (is (= {:get {:responses {200 {:body [[:map [:total :int]]]}}
+                :parameters {:query [[:map [:x :int]]]}},
+          :parameters {:query [[:map [:x :int]]]}
+          :post {}}
+         (impl/path-update
+          {:parameters {:query [:map [:x :int]]}
+           :get {:parameters {:query [:map [:x :int]]}
+                 :responses {200 {:body [:map [:total :int]]}}}
+           :post {}}
+          [[[:parameters any?] vector]
+           [[any? :parameters any?] vector]
+           [[:responses any? :body] vector]
+           [[any? :responses any? :body] vector]]))))

--- a/test/cljc/reitit/impl_test.cljc
+++ b/test/cljc/reitit/impl_test.cljc
@@ -186,3 +186,24 @@
            [[any? :parameters any?] vector]
            [[:responses any? :body] vector]
            [[any? :responses any? :body] vector]]))))
+
+(deftest meta-merge-test
+  (is (= {:get {:responses {200 {:body [[:map [:total :int]]
+                                        [:map [:total :int]]]}},
+                :parameters {:query [[:map [:x :int]]
+                                     [:map [:y :int]]]}},
+          :parameters {:query [[:map [:x :int]]
+                               [:map [:y :int]]]},
+          :post {:parameters {:query [[:map [:y :int]]]}}}
+         (impl/meta-merge
+          {:parameters {:query [:map [:x :int]]}
+           :get {:parameters {:query [:map [:x :int]]}
+                 :responses {200 {:body [:map [:total :int]]}}}}
+          {:parameters {:query [:map [:y :int]]}
+           :get {:parameters {:query [:map [:y :int]]}
+                 :responses {200 {:body [:map [:total :int]]}}}
+           :post {:parameters {:query [:map [:y :int]]}}}
+          {:update-paths [[[:parameters any?] vector]
+                          [[any? :parameters any?] vector]
+                          [[:responses any? :body] vector]
+                          [[any? :responses any? :body] vector]]}))))

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -32,101 +32,101 @@
 
 (def app
   (ring/ring-handler
-    (ring/router
-      ["/api"
-       {:openapi {:id ::math}}
+   (ring/router
+    ["/api"
+     {:openapi {:id ::math}}
 
-       ["/openapi.json"
-        {:get {:no-doc true
-               :openapi {:info {:title "my-api"
-                                :version "0.0.1"}}
-               :handler (openapi/create-openapi-handler)}}]
+     ["/openapi.json"
+      {:get {:no-doc true
+             :openapi {:info {:title "my-api"
+                              :version "0.0.1"}}
+             :handler (openapi/create-openapi-handler)}}]
 
-       ["/spec" {:coercion spec/coercion}
-          ["/plus/:z"
-           {:get {:summary "plus"
-                  :tags [:plus :spec]
-                  :parameters {:query {:x int?, :y int?}
-                               :path {:z int?}}
-                  :openapi {:operationId "spec-plus"
-                            :deprecated true
-                            :responses {400 {:description "kosh"
-                                             :content {"application/json" {:schema {:type "string"}}}}}}
-                  :responses {200 {:description "success"
-                                   :body {:total int?}}
-                              500 {:description "fail"}}
-                  :handler (fn [{{{:keys [x y]} :query
-                                  {:keys [z]} :path} :parameters}]
-                             {:status 200, :body {:total (+ x y z)}})}
-            :post {:summary "plus with body"
-                   :parameters {:body (ds/maybe [int?])
-                                :path {:z int?}}
-                   :openapi {:responses {400 {:content {"application/json" {:schema {:type "string"}}}
-                                              :description "kosh"}}}
-                   :responses {200 {:description "success"
-                                    :body {:total int?}}
-                               500 {:description "fail"}}
-                   :handler (fn [{{{:keys [z]} :path
-                                   xs :body} :parameters}]
-                              {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]
+     ["/spec" {:coercion spec/coercion}
+      ["/plus/:z"
+       {:get {:summary "plus"
+              :tags [:plus :spec]
+              :parameters {:query {:x int?, :y int?}
+                           :path {:z int?}}
+              :openapi {:operationId "spec-plus"
+                        :deprecated true
+                        :responses {400 {:description "kosh"
+                                         :content {"application/json" {:schema {:type "string"}}}}}}
+              :responses {200 {:description "success"
+                               :body {:total int?}}
+                          500 {:description "fail"}}
+              :handler (fn [{{{:keys [x y]} :query
+                              {:keys [z]} :path} :parameters}]
+                         {:status 200, :body {:total (+ x y z)}})}
+        :post {:summary "plus with body"
+               :parameters {:body (ds/maybe [int?])
+                            :path {:z int?}}
+               :openapi {:responses {400 {:content {"application/json" {:schema {:type "string"}}}
+                                          :description "kosh"}}}
+               :responses {200 {:description "success"
+                                :body {:total int?}}
+                           500 {:description "fail"}}
+               :handler (fn [{{{:keys [z]} :path
+                               xs :body} :parameters}]
+                          {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]
 
-       ["/malli" {:coercion malli/coercion}
-        ["/plus/*z"
-         {:get {:summary "plus"
-                :tags [:plus :malli]
-                :parameters {:query [:map [:x int?] [:y int?]]
-                             :path [:map [:z int?]]}
-                :openapi {:responses {400 {:description "kosh"
-                                           :content {"application/json" {:schema {:type "string"}}}}}}
-                :responses {200 {:description "success"
-                                 :body [:map [:total int?]]}
-                            500 {:description "fail"}}
-                :handler (fn [{{{:keys [x y]} :query
-                                {:keys [z]} :path} :parameters}]
-                           {:status 200, :body {:total (+ x y z)}})}
-          :post {:summary "plus with body"
-                 :parameters {:body [:maybe [:vector int?]]
-                              :path [:map [:z int?]]}
-                 :openapi {:responses {400 {:description "kosh"
-                                            :content {"application/json" {:schema {:type "string"}}}}}}
-                 :responses {200 {:description "success"
-                                  :body [:map [:total int?]]}
-                             500 {:description "fail"}}
-                 :handler (fn [{{{:keys [z]} :path
-                                 xs :body} :parameters}]
-                            {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]
+     ["/malli" {:coercion malli/coercion}
+      ["/plus/*z"
+       {:get {:summary "plus"
+              :tags [:plus :malli]
+              :parameters {:query [:map [:x int?] [:y int?]]
+                           :path [:map [:z int?]]}
+              :openapi {:responses {400 {:description "kosh"
+                                         :content {"application/json" {:schema {:type "string"}}}}}}
+              :responses {200 {:description "success"
+                               :body [:map [:total int?]]}
+                          500 {:description "fail"}}
+              :handler (fn [{{{:keys [x y]} :query
+                              {:keys [z]} :path} :parameters}]
+                         {:status 200, :body {:total (+ x y z)}})}
+        :post {:summary "plus with body"
+               :parameters {:body [:maybe [:vector int?]]
+                            :path [:map [:z int?]]}
+               :openapi {:responses {400 {:description "kosh"
+                                          :content {"application/json" {:schema {:type "string"}}}}}}
+               :responses {200 {:description "success"
+                                :body [:map [:total int?]]}
+                           500 {:description "fail"}}
+               :handler (fn [{{{:keys [z]} :path
+                               xs :body} :parameters}]
+                          {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]
 
-       ["/schema" {:coercion schema/coercion}
-        ["/plus/*z"
-         {:get {:summary "plus"
-                :tags [:plus :schema]
-                :parameters {:query {:x s/Int, :y s/Int}
+     ["/schema" {:coercion schema/coercion}
+      ["/plus/*z"
+       {:get {:summary "plus"
+              :tags [:plus :schema]
+              :parameters {:query {:x s/Int, :y s/Int}
                              :path {:z s/Int}}
-                :openapi {:responses {400 {:content {"application/json" {:schema {:type "string"}}}
-                                           :description "kosh"}}}
-                :responses {200 {:description "success"
-                                 :body {:total s/Int}}
-                            500 {:description "fail"}}
-                :handler (fn [{{{:keys [x y]} :query
-                                {:keys [z]} :path} :parameters}]
-                           {:status 200, :body {:total (+ x y z)}})}
-          :post {:summary "plus with body"
-                 :parameters {:body (s/maybe [s/Int])
-                              :path {:z s/Int}}
-                 :openapi {:responses {400 {:content {"application/json" {:schema {:type "string"}}}
-                                            :description "kosh"}}}
-                 :responses {200 {:description "success"
-                                  :body {:total s/Int}}
-                             500 {:description "fail"}}
-                 :handler (fn [{{{:keys [z]} :path
-                                 xs :body} :parameters}]
-                            {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]]
+              :openapi {:responses {400 {:content {"application/json" {:schema {:type "string"}}}
+                                         :description "kosh"}}}
+              :responses {200 {:description "success"
+                               :body {:total s/Int}}
+                          500 {:description "fail"}}
+              :handler (fn [{{{:keys [x y]} :query
+                              {:keys [z]} :path} :parameters}]
+                         {:status 200, :body {:total (+ x y z)}})}
+        :post {:summary "plus with body"
+               :parameters {:body (s/maybe [s/Int])
+                            :path {:z s/Int}}
+               :openapi {:responses {400 {:content {"application/json" {:schema {:type "string"}}}
+                                          :description "kosh"}}}
+               :responses {200 {:description "success"
+                                :body {:total s/Int}}
+                           500 {:description "fail"}}
+               :handler (fn [{{{:keys [z]} :path
+                               xs :body} :parameters}]
+                          {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]]
 
-      {:validate reitit.ring.spec/validate
-       :data {:middleware [openapi/openapi-feature
-                           rrc/coerce-exceptions-middleware
-                           rrc/coerce-request-middleware
-                           rrc/coerce-response-middleware]}})))
+    {:validate reitit.ring.spec/validate
+     :data {:middleware [openapi/openapi-feature
+                         rrc/coerce-exceptions-middleware
+                         rrc/coerce-request-middleware
+                         rrc/coerce-response-middleware]}})))
 
 (deftest openapi-test
   (testing "endpoints work"
@@ -294,21 +294,21 @@
                     {:get {:no-doc true
                            :handler (openapi/create-openapi-handler)}}]
         app (ring/ring-handler
-              (ring/router
-                [["/common" {:openapi {:id #{::one ::two}}}
-                  ping-route]
+             (ring/router
+              [["/common" {:openapi {:id #{::one ::two}}}
+                ping-route]
 
-                 ["/one" {:openapi {:id ::one}}
-                  ping-route
-                  spec-route]
+               ["/one" {:openapi {:id ::one}}
+                ping-route
+                spec-route]
 
-                 ["/two" {:openapi {:id ::two}}
-                  ping-route
-                  spec-route
-                  ["/deep" {:openapi {:id ::one}}
-                   ping-route]]
-                 ["/one-two" {:openapi {:id #{::one ::two}}}
-                  spec-route]]))]
+               ["/two" {:openapi {:id ::two}}
+                ping-route
+                spec-route
+                ["/deep" {:openapi {:id ::one}}
+                 ping-route]]
+               ["/one-two" {:openapi {:id #{::one ::two}}}
+                spec-route]]))]
     (is (= ["/common/ping" "/one/ping" "/two/deep/ping"]
            (spec-paths app "/one/openapi.json")))
     (is (= ["/common/ping" "/two/ping"]
@@ -318,9 +318,9 @@
 
 (deftest openapi-ui-config-test
   (let [app (swagger-ui/create-swagger-ui-handler
-              {:path "/"
-               :url "/openapi.json"
-               :config {:jsonEditor true}})]
+             {:path "/"
+              :url "/openapi.json"
+              :config {:jsonEditor true}})]
     (is (= 302 (:status (app {:request-method :get, :uri "/"}))))
     (is (= 200 (:status (app {:request-method :get, :uri "/index.html"}))))
     (is (= {:jsonEditor true, :url "/openapi.json"}
@@ -329,12 +329,12 @@
 
 (deftest without-openapi-id-test
   (let [app (ring/ring-handler
-              (ring/router
-                [["/ping"
-                  {:get (constantly "ping")}]
-                 ["/openapi.json"
-                  {:get {:no-doc true
-                         :handler (openapi/create-openapi-handler)}}]]))]
+             (ring/router
+              [["/ping"
+                {:get (constantly "ping")}]
+               ["/openapi.json"
+                {:get {:no-doc true
+                       :handler (openapi/create-openapi-handler)}}]]))]
     (is (= ["/ping"] (spec-paths app "/openapi.json")))
     (is (= #{::openapi/default}
            (-> {:request-method :get :uri "/openapi.json"}
@@ -342,14 +342,14 @@
 
 (deftest with-options-endpoint-test
   (let [app (ring/ring-handler
-              (ring/router
-                [["/ping"
-                  {:options (constantly "options")}]
-                 ["/pong"
-                  (constantly "options")]
-                 ["/openapi.json"
-                  {:get {:no-doc true
-                         :handler (openapi/create-openapi-handler)}}]]))]
+             (ring/router
+              [["/ping"
+                {:options (constantly "options")}]
+               ["/pong"
+                (constantly "options")]
+               ["/openapi.json"
+                {:get {:no-doc true
+                       :handler (openapi/create-openapi-handler)}}]]))]
     (is (= ["/ping" "/pong"] (spec-paths app "/openapi.json")))
     (is (= #{::openapi/default}
            (-> {:request-method :get :uri "/openapi.json"}
@@ -370,7 +370,7 @@
                                                                        {:description (str "description " nom)})})]
            [#'spec/coercion (fn [nom] {nom (st/spec {:spec string?
                                                      :description (str "description " nom)})})]]]
-    (testing coercion
+    (testing (str coercion)
       (let [app (ring/ring-handler
                  (ring/router
                   [["/parameters"
@@ -414,9 +414,9 @@
                         :required true
                         :description "description :p"
                         :schema {:type "string"}}]
-                 (-> spec
-                     (get-in [:paths "/parameters" :post :parameters])
-                     normalize))))
+                      (-> spec
+                          (get-in [:paths "/parameters" :post :parameters])
+                          normalize))))
         (testing "body parameter"
           (is (match? (merge {:type "object"
                               :properties {:b {:type "string"}}
@@ -449,9 +449,9 @@
                                          {:openapi/example {nom "EXAMPLE2"}}))]
            [#'spec/coercion (fn [nom]
                               (assoc
-                               (ds/spec ::foo {nom (st/spec string? {:openapi/example "EXAMPLE"})})
-                               :openapi/example {nom "EXAMPLE2"}))]]]
-    (testing coercion
+                                (ds/spec ::foo {nom (st/spec string? {:openapi/example "EXAMPLE"})})
+                                :openapi/example {nom "EXAMPLE2"}))]]]
+    (testing (str coercion)
       (let [app (ring/ring-handler
                  (ring/router
                   [["/examples"
@@ -489,9 +489,9 @@
                         :required true
                         :schema {:type "string"
                                  :example "EXAMPLE"}}]
-                 (-> spec
-                     (get-in [:paths "/examples" :post :parameters])
-                     normalize))))
+                      (-> spec
+                          (get-in [:paths "/examples" :post :parameters])
+                          normalize))))
         (testing "body parameter"
           (is (match? {:schema {:type "object"
                                 :properties {:b {:type "string"
@@ -531,7 +531,7 @@
            [#'spec/coercion
             reitit.http.interceptors.multipart/bytes-part
             string?]]]
-    (testing coercion
+    (testing (str coercion)
       (let [app (ring/ring-handler
                  (ring/router
                   [["/upload"
@@ -569,7 +569,7 @@
           [[#'malli/coercion (fn [nom] [:map [nom :string]])]
            [#'schema/coercion (fn [nom] {nom s/Str})]
            [#'spec/coercion (fn [nom] {nom string?})]]]
-    (testing coercion
+    (testing (str coercion)
       (let [app (ring/ring-handler
                  (ring/router
                   [["/parameters"

--- a/test/cljc/reitit/swagger_test.clj
+++ b/test/cljc/reitit/swagger_test.clj
@@ -114,7 +114,6 @@
                          rrc/coerce-request-middleware
                          rrc/coerce-response-middleware]}})))
 
-(require '[fipp.edn])
 (deftest swagger-test
   (testing "endpoints work"
     (testing "spec"
@@ -430,7 +429,7 @@
            [#'spec/coercion
             reitit.http.interceptors.multipart/bytes-part
             string?]]]
-    (testing coercion
+    (testing (str coercion)
       (let [app (ring/ring-handler
                  (ring/router
                   [["/upload"


### PR DESCRIPTION
welcome 2-phase schema compilation! Fixes #422.

1) use `:update-paths` to handle data in certain (loose) paths differently
   - accumulate schemas in all relevant routers into vector
   - we do not know the coercion here (ring/http have special handling of data, e.g. http-methods)
2) run coercion compiler for the model to merge the effective model
   - schema + malli = should work ok, spec = best effort
3) publish final schemas into compiled route data