### PR TITLE
doc: fix dev_workflow.md code example

### DIFF
--- a/doc/advanced/dev_workflow.md
+++ b/doc/advanced/dev_workflow.md
@@ -142,7 +142,7 @@ Let's apply a small change to our ```ns3```. We'll replace our router by two dif
    ["/ping" ::ping]])
 
 (def dev-router #(r/router (routes))) ;; A router for dev
-(def prod-router (constantly (r/router (routes)))) ;; A router for prod 
+(def prod-router (r/router (routes))) ;; A router for prod 
 ```
 
 And there you have it, dynamic during dev, performance at production. We have it all !


### PR DESCRIPTION
Does the code from L145 really need to be different from the one shown in L32?

If I use `(constantly...)`, I get the following exception:

`Exception: java.lang.IllegalArgumentException: No implementation of method: :match-by-path of protocol: #'reitit.core/Router found for class: clojure.core$constantly$fn__5740`