### PR TITLE
try to fix cljdoc by specifying languages explicitly

### DIFF
--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -14,6 +14,8 @@
   fi.metosin/reitit-sieppari
   fi.metosin/reitit-pedestal
   fi.metosin/reitit-openapi]
+ ;; language autodetect is broken on the main reitit module since it has no source files
+ :cljdoc/languages ["clj" "cljs"]
  :cljdoc.doc/tree
  [["Introduction" {:file "doc/README.md"}]
   ["Basics" {}

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -14,8 +14,6 @@
   fi.metosin/reitit-sieppari
   fi.metosin/reitit-pedestal
   fi.metosin/reitit-openapi]
- ;; language autodetect is broken on the main reitit module since it has no source files
- :cljdoc/languages ["clj" "cljs"]
  :cljdoc.doc/tree
  [["Introduction" {:file "doc/README.md"}]
   ["Basics" {}

--- a/modules/reitit/doc/cljdoc.edn
+++ b/modules/reitit/doc/cljdoc.edn
@@ -1,0 +1,2 @@
+{;; language autodetect is broken on this module since it has no source files
+ :cljdoc/languages ["clj" "cljs"]}

--- a/scripts/cljdoc-check.sh
+++ b/scripts/cljdoc-check.sh
@@ -9,10 +9,6 @@ set -e
 
 for i in modules/*; do
   cd $i
-  if [ "$(ls -A src)" ]; then
-    clojure -J-Dclojure.main.report=stderr -Tcljdoc-analyzer analyze-local
-  else
-    echo "Skip $i, empty src folder"
-  fi
+  clojure -J-Dclojure.main.report=stderr -Tcljdoc-analyzer analyze-local
   cd ../..
 done


### PR DESCRIPTION
currently, the build is failing with:

```
2023-09-11 12:24:26,526 INFO  cljdoc-analyzer.runner - launching metagetta for: fi.metosin/reitit languages: :auto-detect
2023-09-11 12:24:28,432 INFO  cljdoc-analyzer.runner - metagetta results:
exit-code 1
;; full error omitted
Execution error (ExceptionInfo) at cljdoc-analyzer.metagetta.utils/infer-platforms-from-src-dir (utils.clj:118).
no Clojure/Clojurescript sources found
```

see e.g. https://app.circleci.com/pipelines/github/cljdoc/builder/45669/workflows/cf9bcefe-63b5-4bec-9365-a3c6159f1b94/jobs/62044