### PR TITLE
Update Clojure version of all Swagger Examples to 1.11

### DIFF
--- a/examples/http-swagger/project.clj
+++ b/examples/http-swagger/project.clj
@@ -1,6 +1,6 @@
 (defproject ring-example "0.1.0-SNAPSHOT"
   :description "Reitit Http App with Swagger"
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [ring/ring-jetty-adapter "1.7.1"]
                  [aleph "0.4.7-alpha5"]
                  [fi.metosin/reitit "0.7.0-alpha6"]

--- a/examples/pedestal-malli-swagger/project.clj
+++ b/examples/pedestal-malli-swagger/project.clj
@@ -1,6 +1,6 @@
 (defproject pedestal-malli-swagger-example "0.1.0-SNAPSHOT"
   :description "Reitit-http with pedestal"
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [io.pedestal/pedestal.service "0.5.5"]
                  [io.pedestal/pedestal.jetty "0.5.5"]
                  [fi.metosin/reitit-malli "0.7.0-alpha6"]

--- a/examples/pedestal-swagger/project.clj
+++ b/examples/pedestal-swagger/project.clj
@@ -1,6 +1,6 @@
 (defproject ring-example "0.1.0-SNAPSHOT"
   :description "Reitit-http with pedestal"
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [io.pedestal/pedestal.service "0.5.5"]
                  [io.pedestal/pedestal.jetty "0.5.5"]
                  [fi.metosin/reitit-pedestal "0.7.0-alpha6"]

--- a/examples/ring-malli-lite-swagger/project.clj
+++ b/examples/ring-malli-lite-swagger/project.clj
@@ -1,6 +1,6 @@
 (defproject ring-example "0.1.0-SNAPSHOT"
   :description "Reitit Ring App with Swagger"
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [metosin/jsonista "0.2.6"]
                  [ring/ring-jetty-adapter "1.7.1"]
                  [fi.metosin/reitit "0.7.0-alpha6"]]

--- a/examples/ring-malli-swagger/project.clj
+++ b/examples/ring-malli-swagger/project.clj
@@ -1,6 +1,6 @@
 (defproject ring-example "0.1.0-SNAPSHOT"
   :description "Reitit Ring App with Swagger"
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [metosin/jsonista "0.2.6"]
                  [ring/ring-jetty-adapter "1.7.1"]
                  [fi.metosin/reitit "0.7.0-alpha6"]

--- a/examples/ring-spec-swagger/project.clj
+++ b/examples/ring-spec-swagger/project.clj
@@ -1,6 +1,6 @@
 (defproject ring-example "0.1.0-SNAPSHOT"
   :description "Reitit Ring App with Swagger"
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [ring/ring-jetty-adapter "1.7.1"]
                  [fi.metosin/reitit "0.7.0-alpha6"]
                  [metosin/ring-swagger-ui "5.0.0-alpha.0"]]


### PR DESCRIPTION
As of 497da675b92d2d50b00feaf3ff662145a04a250d (committed 1st Sept 2023), `swagger.cljc` uses the `update-vals` function, introduced in Clojure 1.11.

Due to this, all the example projects fail to run since the `project.clj` specifies Clojure version 1.10.

This commit updates the Clojure version for such examples, fixing the problem.

Fixes: #651