### PR TITLE
Correct "effects" to "affects" in comments & docs

### DIFF
--- a/doc/coercion/malli_coercion.md
+++ b/doc/coercion/malli_coercion.md
@@ -84,7 +84,7 @@ Using `create` with options to create the coercion instead of `coercion`:
    :validate true
    ;; top-level short-circuit to disable request & response coercion
    :enabled true
-   ;; strip-extra-keys (effects only predefined transformers)
+   ;; strip-extra-keys (affects only predefined transformers)
    :strip-extra-keys true
    ;; add/set default values
    :default-values true

--- a/examples/ring-malli-lite-swagger/src/example/server.clj
+++ b/examples/ring-malli-lite-swagger/src/example/server.clj
@@ -83,7 +83,7 @@
                            :error-keys #{#_:type :coercion :in :schema :value :errors :humanized #_:transformed}
                            ;; schema identity function (default: close all map schemas)
                            :compile mu/closed-schema
-                           ;; strip-extra-keys (effects only predefined transformers)
+                           ;; strip-extra-keys (affects only predefined transformers)
                            :strip-extra-keys true
                            ;; add/set default values
                            :default-values true

--- a/examples/ring-malli-swagger/src/example/server.clj
+++ b/examples/ring-malli-swagger/src/example/server.clj
@@ -123,7 +123,7 @@
                            :error-keys #{#_:type :coercion :in :schema :value :errors :humanized #_:transformed}
                            ;; schema identity function (default: close all map schemas)
                            :compile mu/closed-schema
-                           ;; strip-extra-keys (effects only predefined transformers)
+                           ;; strip-extra-keys (affects only predefined transformers)
                            :strip-extra-keys true
                            ;; add/set default values
                            :default-values true

--- a/modules/reitit-malli/src/reitit/coercion/malli.cljc
+++ b/modules/reitit-malli/src/reitit/coercion/malli.cljc
@@ -97,7 +97,7 @@
    :validate true
    ;; top-level short-circuit to disable request & response coercion
    :enabled true
-   ;; strip-extra-keys (effects only predefined transformers)
+   ;; strip-extra-keys (affects only predefined transformers)
    :strip-extra-keys true
    ;; add/set default values
    :default-values true


### PR DESCRIPTION
Their usage is commonly confused, but "affect" is usually a verb and "effect" is usually a noun. In this case we want the verb. See also https://www.merriam-webster.com/grammar/affect-vs-effect-usage-difference