### PR TITLE
Fix formatting of #'router docstring

### DIFF
--- a/modules/reitit-ring/src/reitit/ring.cljc
+++ b/modules/reitit-ring/src/reitit/ring.cljc
@@ -116,10 +116,10 @@
 
       (router
         [\"/api\" {:middleware [wrap-format wrap-oauth2]}
-          [\"/users\" {:get get-user
-                       :post update-user
-                       :delete {:middleware [wrap-delete]
-                               :handler delete-user}}]])"
+         [\"/users\" {:get get-user
+                    :post update-user
+                    :delete {:middleware [wrap-delete]
+                             :handler delete-user}}]])"
   ([data]
    (router data nil))
   ([data opts]


### PR DESCRIPTION
Escaped double quotes breaks the clojure.repl/doc output.

Before:

```clojure
      (router
        ["/api" {:middleware [wrap-format wrap-oauth2]}
          ["/users" {:get get-user
                       :post update-user
                       :delete {:middleware [wrap-delete]
                               :handler delete-user}}]])
```

After:

```clojure
      (router
        ["/api" {:middleware [wrap-format wrap-oauth2]}
         ["/users" {:get get-user
                    :post update-user
                    :delete {:middleware [wrap-delete]
                             :handler delete-user}}]])
```