### PR TITLE
add parsing of query params to match-by-path in reitit.core

### DIFF
--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -112,6 +112,7 @@
          (if-let [match (match-by-path path)]
            (-> (:data match)
                (assoc :path-params (:params match))
+               (assoc :query-params (impl/query-params path))
                (assoc :path path))))
        (match-by-name [_ name]
          (if-let [match (impl/fast-get lookup name)]
@@ -198,6 +199,7 @@
          (if-let [match (and match-by-path (match-by-path path))]
            (-> (:data match)
                (assoc :path-params (:params match))
+               (assoc :query-params (impl/query-params path))
                (assoc :path path))))
        (match-by-name [_ name]
          (if-let [match (impl/fast-get lookup name)]

--- a/modules/reitit-frontend/src/reitit/frontend.cljs
+++ b/modules/reitit-frontend/src/reitit/frontend.cljs
@@ -63,6 +63,7 @@
                             (throw e))))
                    coercion/coerce!)]
      (if-let [match (r/match-by-path router (.getPath uri))]
+       ;; query-params already part of match here (TODO ensure getPath includes query)
        (let [q (query-params uri)
              fragment (when (.hasFragment uri)
                         (.getFragment uri))

--- a/test/cljc/reitit/core_test.cljc
+++ b/test/cljc/reitit/core_test.cljc
@@ -435,3 +435,9 @@
 (deftest routing-bug-test-538
   (let [router (r/router [["/:a"] ["/:b"]] {:conflicts nil})]
     (is (nil? (r/match-by-path router "")))))
+
+(deftest query-string-support
+  (let [router (r/router [["/endpoint"]])
+        match (r/match-by-path router "/endpoint?foo=bar&foo=baz&some=123")]
+    (is (= ["bar" "baz"] (:foo (:query-params match))))
+    (is (= ["123"] (:some (:query-params match))))))


### PR DESCRIPTION
The motivation behind this PR is to make `match-by-path` behave consistently no matter if you use `reitit.core/match-by-path` or `reitit.frontend/match-by-path`. 

