### PR TITLE
Update ring-swagger-ui for support openapi 3.1.0 version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                          [metosin/reitit-frontend "0.7.0-alpha7"]
                          [metosin/reitit-sieppari "0.7.0-alpha7"]
                          [metosin/reitit-pedestal "0.7.0-alpha7"]
-                         [metosin/ring-swagger-ui "4.19.1"]
+                         [metosin/ring-swagger-ui "5.9.0"]
                          [metosin/spec-tools "0.10.5"]
                          [metosin/schema-tools "0.13.1"]
                          [metosin/muuntaja "0.6.8"]


### PR DESCRIPTION
The need for such a change is that reitit-openapi module creates openapi.js of 3.1.0 version, but current reitit-swagger-ui can't draw it, because dependency through root to ring-swagger-ui . ring-swagger-ui > 5.x.x version can draw openapi.js 3.1.0 version correctly

I add pic in #[1011](https://github.com/metosin/malli/issues/1011) issue, which I created before I figured out the problem