### PR TITLE
fix: remove unsupported coercions when generating swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 * Handlers can be vars [#585](https://github.com/metosin/reitit/pull/585)
 * Fetch OpenAPI content types from Muuntaja [#636](https://github.com/metosin/reitit/issues/636)
 * **BREAKING** OpenAPI support is now clj only
+* Fix swagger generation when unsupported coercions are present [#671](https://github.com/metosin/reitit/pull/671)
 * Updated dependencies:
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ All main modules bundled:
 
 Optionally, the parts can be required separately.
 
+Reitit requires Clojure 1.11.
+
 ## Quick start
 
 ```clj


### PR DESCRIPTION
If we don't remove them, :responses :content gets passed out verbatim
in the swagger.json, breaking stuff.

In particular, fixes the swagger.json in
examples/reitit-malli-swagger. Reported broken in #669.