### PR TITLE
Generate correct OpenAPI $ref schemas for malli var and ref schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 * Fetch OpenAPI content types from Muuntaja [#636](https://github.com/metosin/reitit/issues/636)
 * **BREAKING** OpenAPI support is now clj only
 * Fix swagger generation when unsupported coercions are present [#671](https://github.com/metosin/reitit/pull/671)
+* Generate correct OpenAPI $ref schemas for malli var and ref schemas [#673](https://github.com/metosin/reitit/pull/673)
 * Updated dependencies:
 
 ```clojure

--- a/examples/openapi/src/example/server.clj
+++ b/examples/openapi/src/example/server.clj
@@ -12,7 +12,27 @@
             [reitit.ring.middleware.multipart :as multipart]
             [reitit.ring.middleware.parameters :as parameters]
             [ring.adapter.jetty :as jetty]
+            [malli.core :as malli]
             [muuntaja.core :as m]))
+
+(def Transaction
+  [:map
+   [:amount :double]
+   [:from :string]])
+
+(def AccountId
+  [:map
+   [:bank :string]
+   [:id :string]])
+
+(def Account
+  [:map
+   [:bank :string]
+   [:id :string]
+   [:balance :double]
+   [:transactions [:vector #'Transaction]]])
+
+
 
 (def app
   (ring/ring-handler
@@ -89,8 +109,23 @@
                                                               [:email {:json-schema/example "heidi@alps.ch"}
                                                                string?]]]}}}}
                :handler (fn [_request]
-                          [{:name "Heidi"
-                            :email "heidi@alps.ch"}])}}]
+                          {:status 200
+                           :body [{:name "Heidi"
+                                   :email "heidi@alps.ch"}]})}}]
+
+       ["/account"
+        {:get {:summary "Fetch an account | Recursive schemas using malli registry"
+               :parameters {:query #'AccountId}
+               :responses {200 {:content {:default {:schema #'Account}}}}
+               :handler (fn [_request]
+                          {:status 200
+                           :body {:bank "MiniBank"
+                                  :id "0001"
+                                  :balance 13.5
+                                  :transactions [{:from "0002"
+                                                  :amount 20.0}
+                                                 {:from "0003"
+                                                  :amount -6.5}]}})}}]
 
        ["/secure"
         {:tags #{"secure"}

--- a/modules/reitit-malli/src/reitit/coercion/malli.cljc
+++ b/modules/reitit-malli/src/reitit/coercion/malli.cljc
@@ -122,7 +122,12 @@
        (-get-options [_] opts)
        (-get-model-apidocs [this specification model options]
          (case specification
-           :openapi (json-schema/transform model (merge opts options))
+           :openapi (if (= :parameter (:type options))
+                      ;; For :parameters we need to output an object schema with actual :properties.
+                      ;; The caller will iterate through the properties and add them individually to the openapi doc.
+                      ;; Thus, we deref to get the actual [:map ..] instead of some ref-schema.
+                      (json-schema/transform (m/deref model) (merge opts options))
+                      (json-schema/transform model (merge opts options)))
            (throw
             (ex-info
              (str "Can't produce Malli apidocs for " specification)

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -901,9 +901,9 @@
                                                                                           :additionalProperties false},
                                                                                  :examples {"2" {:total 2}, "3" {:total 3}},
                                                                                  :example {:total 4}}}}},
-                                  :summary "plus with body"}}})
-        (-> {:request-method :get
-             :uri "/openapi.json"}
-            (app)
-            :body
-            :paths))))
+                                  :summary "plus with body"}}}
+           (-> {:request-method :get
+                :uri "/openapi.json"}
+               (app)
+               :body
+               :paths)))))

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -844,16 +844,16 @@
                       :requestBody
                       {:content
                        {"application/json"
-                        {:schema {:$ref "#/definitions/friend"
-                                  :definitions {"friend" {:properties {:age {:type "integer"}
-                                                                       :pet {:$ref "#/definitions/pet"}}
-                                                          :required [:age :pet]
-                                                          :type "object"}
-                                                "pet" {:properties {:friends {:items {:$ref "#/definitions/friend"}
-                                                                              :type "array"}
-                                                                    :name {:type "string"}}
-                                                       :required [:name :friends]
-                                                       :type "object"}}}}}}}}}}
+                        {:schema {:$ref "#/components/schemas/friend"}}}}}}}
+            :components {:schemas {"friend" {:properties {:age {:type "integer"}
+                                                          :pet {:$ref "#/components/schemas/pet"}}
+                                             :required [:age :pet]
+                                             :type "object"}
+                                   "pet" {:properties {:friends {:items {:$ref "#/components/schemas/friend"}
+                                                                 :type "array"}
+                                                       :name {:type "string"}}
+                                          :required [:name :friends]
+                                          :type "object"}}}}
            spec))
     (testing "spec is valid"
       (is (nil? (validate spec))))))


### PR DESCRIPTION
Collect all the json-schema `:definitions` and place them under `:components :schemas` in the OpenAPI document.

Depends on metosin/malli#1045 (should be in 0.16.0).

Fixes #645. Fixes #669. Implements the malli part of #616. 