### PR TITLE
fix: fix bug where http ring handler would cause :path to be applied twice

### DIFF
--- a/modules/reitit-http/src/reitit/http.cljc
+++ b/modules/reitit-http/src/reitit/http.cljc
@@ -133,7 +133,7 @@
                             (interceptor/queue executor))
          router-opts (-> (r/options router)
                          (assoc ::interceptor/queue (partial interceptor/queue executor))
-                         (dissoc :data) ; data is already merged into routes
+                         (dissoc :data :path) ; data and path already take effect in routes
                          (cond-> (seq interceptors)
                            (update-in [:data :interceptors] (partial into (vec interceptors)))))
          router (reitit.http/router (r/routes router) router-opts) ;; will re-compile the interceptors


### PR DESCRIPTION
Prior to this change, ring-handler caused the `:path` to be added twice to each path:


```clj
;setup
(require '[reitit.http :as rhttp]
         '[reitit.ring :as ring]
         '[reitit.interceptor.sieppari :as sieppari])

(def router (rhttp/router
              [["/test1" (fn test1 [_] {:status 200
                                        :body   {:endpoint "/test1"}})]
               ["/nested/test2" (fn test2 [_] {:status 200
                                               :body   {:endpoint "/nested/test2"}})]]
              {:path "/api"}))

(def handler (rhttp/ring-handler
                 router
                 (ring/routes
                   (ring/create-default-handler))
                 {:executor sieppari/executor}))

;tests
;router looks correct
(reitit.core/routes router)
=>
[["/api/test1" {:handler #object[prism.http_server$test1__18983 0xc999d32f "prism.http_server$test1__18983@c999d32f"]}]
 ["/api/nested/test2"
  {:handler #object[prism.http_server$test2__18985 0x5b7f1a67 "prism.http_server$test2__18985@5b7f1a67"]}]]

;handler does not match router
(handler {:uri            "/api/test1"
          :request-method :get})
=> {:status 404, :body "", :headers {}}

;paths present under two `/api` levels
(handler {:uri            "/api/api/test1"
          :request-method :get})
=> {:status 200, :body {:endpoint "/test1"}}

(handler {:uri            "/api/api/nested/test2"
          :request-method :get})
=> {:status 200, :body {:endpoint "/nested/test2"}}

```