### PR TITLE
Add OpenAPI :requestBody for :form request schema

### DIFF
--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -739,6 +739,13 @@
                             :handler (fn [req]
                                        {:status 200
                                         :body (-> req :parameters :request)})}}]
+                   ["/form-params"
+                    {:post {:description "ring :form-params coercion with :parameters :form syntax"
+                            :coercion coercion
+                            :parameters {:form (->schema :b)}
+                            :handler (fn [req]
+                                       {:status 200
+                                        :body (-> req :parameters :request)})}}]
                    ["/openapi.json"
                     {:get {:handler (openapi/create-openapi-handler)
                            :openapi {:info {:title "" :version "0.0.1"}}
@@ -801,6 +808,13 @@
                    (-> spec
                        (get-in [:paths "/legacy" :post :responses 200 :content])
                        keys)))))
+        (testing ":parameters :form syntax"
+          (testing "body parameter"
+            (is (= ["application/x-www-form-urlencoded"]
+                   (-> spec
+                       (get-in [:paths "/form-params" :post :requestBody :content])
+                       keys))
+                "form parameter schema is put under :requestBody with correct content type")))
         (testing "spec is valid"
           (is (nil? (validate spec))))))))
 


### PR DESCRIPTION
[Ring Coercion](https://github.com/metosin/reitit/blob/master/doc/ring/coercion.md) functionality allows defining a request schema with `{:parameters {:form some-schema}}`. This resulted in that schema being transformed to OpenAPI parameters, which was supported in OAS 2 (Swagger), [but is not supported in OAS 3](https://swagger.io/docs/specification/v3_0/describing-request-body/describing-request-body/#differences-from-openapi-20). Now they must be defined as a `requestBody` schema like any other kind of body. 

`:form` parameter coercion also implies that the request content type must be `application/x-www-form-urlencoded`.

