### PR TITLE
Place the openapi deprecation tag directly under parameters

### DIFF
--- a/doc/ring/openapi.md
+++ b/doc/ring/openapi.md
@@ -139,6 +139,7 @@ Malli:
            [:x
             {:title "X parameter"
              :description "Description for X parameter"
+             :json-schema/deprecated true
              :json-schema/default 42}
             int?]
            [:y int?]]}}}]
@@ -151,6 +152,7 @@ Schema:
  {:post
   {:parameters
    {:body {:x (schema-tools.core/schema s/Num {:description "Description for X parameter"
+                                               :openapi/deprecated true
                                                :openapi/example 13
                                                :openapi/default 42})
            :y int?}}}}]
@@ -165,6 +167,7 @@ Spec:
    {:body (spec-tools.data-spec/spec ::foo
                                      {:x (schema-tools.core/spec {:spec int?
                                                                   :description "Description for X parameter"
+                                                                  :openapi/deprecated true
                                                                   :openapi/example 13
                                                                   :openapi/default 42})
                                       :y int?}}}}}]

--- a/examples/openapi/src/example/server.clj
+++ b/examples/openapi/src/example/server.clj
@@ -97,6 +97,10 @@
                                              :json-schema/default 30
                                              :json-schema/example 10}
                                      int?]
+                                    [:charset {:title "Which charset to use?"
+                                               :optional true
+                                               :json-schema/deprecated true}
+                                     string?]
                                     [:email {:title "Email address to search for"
                                              :json-schema/format "email"}
                                      string?]]}

--- a/modules/reitit-openapi/src/reitit/openapi.clj
+++ b/modules/reitit-openapi/src/reitit/openapi.clj
@@ -110,8 +110,9 @@
                (merge {:in (name in)
                        :name k
                        :required (required? k)
-                       :schema schema}
-                      (select-keys schema [:description])))
+                       :schema (dissoc schema :deprecated)}
+                      (select-keys schema [:description])
+                      (when (:deprecated schema) {:deprecated true})))
              (into []))})
      (when body
        ;; :body uses a single schema to describe every :requestBody

--- a/modules/reitit-openapi/src/reitit/openapi.clj
+++ b/modules/reitit-openapi/src/reitit/openapi.clj
@@ -110,9 +110,8 @@
                (merge {:in (name in)
                        :name k
                        :required (required? k)
-                       :schema (dissoc schema :deprecated)}
-                      (select-keys schema [:description])
-                      (when (:deprecated schema) {:deprecated true})))
+                       :schema (dissoc schema :description :deprecated)}
+                      (select-keys schema [:description :deprecated])))
              (into []))})
      (when body
        ;; :body uses a single schema to describe every :requestBody

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -171,8 +171,7 @@
                                                                       :deprecated true
                                                                       :required true
                                                                       :schema {:type "integer"
-                                                                               :format "int64"
-                                                                               :description "this is deprecated"}}
+                                                                               :format "int64"}}
                                                                      {:in "path"
                                                                       :name "z"
                                                                       :required true
@@ -221,8 +220,7 @@
                                                                        :required true
                                                                        :description "this is deprecated"
                                                                        :deprecated true
-                                                                       :schema {:type "integer"
-                                                                                :description "this is deprecated"}}
+                                                                       :schema {:type "integer"}}
                                                                       {:in "path"
                                                                        :name :z
                                                                        :required true
@@ -269,8 +267,7 @@
                                                                         :description "this is deprecated"
                                                                         :deprecated true
                                                                         :schema {:type "integer"
-                                                                                 :format "int32"
-                                                                                 :description "this is deprecated"}}
+                                                                                 :format "int32"}}
                                                                        {:in "path"
                                                                         :name "z"
                                                                         :required true

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -47,7 +47,9 @@
       ["/plus/:z"
        {:get {:summary "plus"
               :tags [:plus :spec]
-              :parameters {:query {:x int?, :y int?}
+              :parameters {:query {:x int?, :y (st/spec {:spec int?
+                                                         :description "this is deprecated"
+                                                         :openapi/deprecated true})}
                            :path {:z int?}}
               :openapi {:operationId "spec-plus"
                         :deprecated true
@@ -78,7 +80,8 @@
       ["/plus/*z"
        {:get {:summary "plus"
               :tags [:plus :malli]
-              :parameters {:query [:map [:x int?] [:y int?]]
+              :parameters {:query [:map [:x int?] [:y {:json-schema/deprecated true
+                                                       :description "this is deprecated"} int?]]
                            :path [:map [:z int?]]}
               :openapi {:responses {400 {:description "kosh"
                                          :content {"application/json" {:schema {:type "string"}}}}}}
@@ -107,7 +110,8 @@
       ["/plus/*z"
        {:get {:summary "plus"
               :tags [:plus :schema]
-              :parameters {:query {:x s/Int, :y s/Int}
+              :parameters {:query {:x s/Int, :y (schema-tools.core/schema s/Int {:description "this is deprecated"
+                                                                                 :openapi/deprecated true})}
                            :path {:z s/Int}}
               :openapi {:responses {400 {:content {"application/json" {:schema {:type "string"}}}
                                          :description "kosh"}}}
@@ -163,9 +167,12 @@
                                                                                :format "int64"}}
                                                                      {:in "query"
                                                                       :name "y"
+                                                                      :description "this is deprecated"
+                                                                      :deprecated true
                                                                       :required true
                                                                       :schema {:type "integer"
-                                                                               :format "int64"}}
+                                                                               :format "int64"
+                                                                               :description "this is deprecated"}}
                                                                      {:in "path"
                                                                       :name "z"
                                                                       :required true
@@ -212,7 +219,10 @@
                                                                       {:in "query"
                                                                        :name :y
                                                                        :required true
-                                                                       :schema {:type "integer"}}
+                                                                       :description "this is deprecated"
+                                                                       :deprecated true
+                                                                       :schema {:type "integer"
+                                                                                :description "this is deprecated"}}
                                                                       {:in "path"
                                                                        :name :z
                                                                        :required true
@@ -256,8 +266,11 @@
                                                                        {:in "query"
                                                                         :name "y"
                                                                         :required true
+                                                                        :description "this is deprecated"
+                                                                        :deprecated true
                                                                         :schema {:type "integer"
-                                                                                 :format "int32"}}
+                                                                                 :format "int32"
+                                                                                 :description "this is deprecated"}}
                                                                        {:in "path"
                                                                         :name "z"
                                                                         :required true


### PR DESCRIPTION
When creating an openapi handler via reitit.openapi/create-openapi-handler the parameter deprecation tags are put under the schema tag, not directly under the parameters tag.

https://swagger.io/docs/specification/v3_0/describing-parameters/#deprecated-parameters

The openapi.json generated without this fix:
```json
          {
            "in": "query",
            "name": "include-legacy-information",
            "required": false,
            "schema": {
              "deprecated": true
            },
          },
```

The openapi.json generated with this fix:
```json
          {
            "in": "query",
            "name": "include-legacy-information",
            "required": false,
            "schema": {},
            "deprecated": true
          },
```

I was able to run these tests, that passed:
./scripts/test.sh clj 
but not these, that failed for an unrelated reason:
./scripts/test.sh cljs