### PR TITLE
Add regex based router

### DIFF
--- a/modules/reitit-core/src/reitit/regex.cljc
+++ b/modules/reitit-core/src/reitit/regex.cljc
@@ -1,0 +1,121 @@
+(ns reitit.regex
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [reitit.core :as r]))
+
+(defn compile-regex-route
+  "Given a route vector [path route-data], returns a map with:
+   - :pattern: a compiled regex pattern built from the path segments,
+   - :group-keys: vector of parameter keys in order,
+   - :route-data: the provided route data,
+   - :original-segments: original path segments for path generation,
+   - :template: the original path template for Match objects."
+  [[path route-data]]
+  (let [;; Normalize route-data to ensure it's a map with :name
+        route-data (if (keyword? route-data)
+                     {:name route-data}
+                     route-data)
+
+        ;; Store the original path template for Match objects
+        template (if (str/starts-with? path "/")
+                   path
+                   (str "/" path))
+
+        ;; Handle paths with or without leading slashes
+        normalized-path (cond-> path
+                                (str/starts-with? path "/") (subs 1))
+
+        ;; Split into segments, handling empty paths
+        segments (if (empty? normalized-path)
+                   []
+                   (str/split normalized-path #"/"))
+
+        ;; Store original segments for path generation
+        original-segments segments
+
+        compiled-segments
+        (map (fn [seg]
+               (if (str/starts-with? seg ":")
+                 (let [param-key   (keyword (subs seg 1))
+                       param-regex (get-in route-data [:parameters :path param-key])]
+                   (if (and param-regex (instance? java.util.regex.Pattern param-regex))
+                     (str "(" (.pattern ^java.util.regex.Pattern param-regex) ")")
+                     ;; Fallback: match any non-slash characters.
+                     "([^/]+)"))
+                 (java.util.regex.Pattern/quote seg)))
+             segments)
+
+        ;; Create the pattern string, handling special case for root path
+        pattern-str (if (empty? segments)
+                      "^/?$"  ;; Match root path with optional trailing slash
+                      (str "^/" (str/join "/" compiled-segments) "$"))
+
+        group-keys (->> segments
+                        (filter #(str/starts-with? % ":"))
+                        (map #(keyword (subs % 1)))
+                        (vec))]
+
+    {:pattern    (re-pattern pattern-str)
+     :group-keys group-keys
+     :route-data route-data
+     :original-segments original-segments
+     :template template}))
+
+(defn- generate-path
+  "Generate a path from a route and path parameters."
+  [route path-params]
+  (if (empty? (:original-segments route))
+    "/"
+    (str "/" (str/join "/"
+                       (map (fn [segment]
+                              (if (str/starts-with? segment ":")
+                                (let [param-key (keyword (subs segment 1))]
+                                  (get path-params param-key ""))
+                                segment))
+                            (:original-segments route))))))
+
+(defrecord RegexRouter [compiled-routes]
+  r/Router
+  (router-name [_] :regex-router)
+
+  (routes [_]
+    (mapv (fn [{:keys [route-data original-segments]}]
+            [(str "/" (str/join "/" original-segments)) route-data])
+          compiled-routes))
+
+  (compiled-routes [_] compiled-routes)
+
+  (options [_] {})
+
+  (route-names [_]
+    (keep (comp :name :route-data) compiled-routes))
+
+  (match-by-path [_ path]
+    (some (fn [{:keys [pattern group-keys route-data template]}]
+            (when-let [matches (re-matches pattern path)]
+              (let [params (zipmap group-keys (rest matches))]
+                (r/->Match template route-data nil params path))))
+          compiled-routes))
+
+  (match-by-name [this name]
+    (r/match-by-name this name {}))
+
+  (match-by-name [router name path-params]
+    (when-let [{:keys [group-keys route-data template] :as route}
+               (first (filter #(= name (get-in % [:route-data :name])) (r/compiled-routes router)))]
+      ;; Check if all required params are provided
+      (let [required-params (set group-keys)
+            provided-params (set (keys path-params))]
+        (if (every? #(contains? provided-params %) required-params)
+          ;; All required params provided, return a Match
+          (let [path (generate-path route path-params)]
+            (r/->Match template route-data nil path-params path))
+          ;; Some required params missing, return a PartialMatch
+          (let [missing (set/difference required-params provided-params)]
+            (r/->PartialMatch template route-data nil path-params missing)))))))
+
+(defn create-regex-router
+  "Create a RegexRouter from a vector of routes.
+   Each route should be a vector [path route-data]."
+  [routes]
+  (->RegexRouter (mapv compile-regex-route routes)))

--- a/modules/reitit-core/src/reitit/regex.cljc
+++ b/modules/reitit-core/src/reitit/regex.cljc
@@ -1,7 +1,30 @@
 (ns reitit.regex
+  "A reitit Router implementation that matches paths with regular expressions.
+
+   Path segments support the standard reitit syntaxes plus a regex-constrained
+   form:
+   - `:name` / `{name}`   wildcard, matches a single path segment.
+   - `:#name`             regex-constrained segment; the pattern is looked up in
+                          the route-data under `[:path-regex name]` (a regex or
+                          a string), and must be present or compilation throws.
+   - `*name` / `{*name}`  catch-all, matches the rest of the path, including `/`.
+   - anything else        a static segment, matched literally.
+
+   Matching is linear and first-match-wins, in declaration order. Order routes
+   from most to least specific; place broad regex/catch-all matchers after the
+   specific routes they would otherwise shadow.
+
+   Path generation: a `:#` regex param's value is emitted verbatim; its regex
+   is the contract for what is valid, and may legitimately allow `/`, `@`, etc.
+   Bare wildcard segments are percent-encoded; on match, params are URL-decoded.
+
+   Coercion: this router threads reitit's compiled `:result` through to every
+   Match, so request coercion works exactly as with the built-in routers when
+   the router is built with the same `:compile` option."
   (:require [clojure.set :as set]
             [clojure.string :as str]
-            [reitit.core :as r])
+            [reitit.core :as r]
+            [reitit.impl :as impl])
   #?(:clj (:import [java.util.regex Pattern])))
 
 (defn regex?
@@ -14,7 +37,7 @@
   "Gets the pattern string from a regex in both Clojure and ClojureScript."
   [regex-obj]
   #?(:clj (.pattern ^Pattern regex-obj)
-     :cljs (.-source regex-obj)))
+     :cljs (str (.-source regex-obj))))
 
 (defn regex-quote
   "Escapes a string for regex in both Clojure and ClojureScript."
@@ -22,125 +45,181 @@
   #?(:clj (Pattern/quote s)
      :cljs (str/replace s #"[.*+?^${}\(\)|\[\]\\]" "\\$&")))
 
-(defn- regex-param-segment? [segment]
-  (str/starts-with? segment ":#"))
+(defn- count-capturing-groups
+  "Number of capturing groups contained in the regex pattern string. Used to
+   keep the combined route pattern's group indices aligned with the parameter
+   list even when a user-supplied regex contains its own capturing groups."
+  [pattern-string]
+  #?(:clj (.groupCount (.matcher (re-pattern pattern-string) ""))
+     ;; Appending an empty alternative forces a match against "", so .exec
+     ;; always returns an array whose length is capturing-groups + 1.
+     :cljs (dec (.-length (.exec (js/RegExp. (str pattern-string "|")) "")))))
 
-(defn- param-segment? [segment]
-  (str/starts-with? segment ":"))
+;; Characters that are legal inside a single URL path segment per RFC 3986
+;; (pchar = unreserved / sub-delims / ":" / "@"). Anything outside this set is
+;; percent-encoded when generating a path. `:#` regex params are emitted verbatim
+;; because their route regex is the validity contract.
+(def ^:private path-segment-unsafe-re #"[^A-Za-z0-9!$&'()*+,;=:@._~-]+")
 
-(defn- param-key [segment]
-  (keyword (subs segment (if (regex-param-segment? segment) 2 1))))
+(defn- url-encode-segment
+  "Percent-encodes `s` for use within a single URL path segment, leaving
+   path-legal characters, including `@`, intact. Returns nil for nil."
+  [s]
+  (when s
+    (str/replace s path-segment-unsafe-re
+                 (fn [m] #?(:clj (impl/percent-encode m)
+                            :cljs (js/encodeURIComponent m))))))
 
-(defn- string->regex [s]
-  (try
-    (re-pattern s)
-    (catch #?(:clj Exception :cljs js/Error) _
-      nil)))
+(defn- param-key
+  "The keyword name from a parameter segment, stripping the syntax prefix."
+  [seg]
+  (cond
+    (str/starts-with? seg ":#") (keyword (subs seg 2))
+    (str/starts-with? seg "*") (keyword (subs seg 1))
+    (and (str/starts-with? seg "{*") (str/ends-with? seg "}")) (keyword (subs seg 2 (dec (count seg))))
+    (and (str/starts-with? seg "{") (str/ends-with? seg "}")) (keyword (subs seg 1 (dec (count seg))))
+    (str/starts-with? seg ":") (keyword (subs seg 1))))
+
+(defn- parse-segment
+  "Classifies a raw path segment into a parsed segment map. Supported forms:
+   - `:name`        wildcard, matching a single path segment
+   - `{name}`       wildcard, bracket syntax
+   - `:#name`       regex-constrained segment from route-data `:path-regex`
+   - `*name`        catch-all matching the rest of the path, including slashes
+   - `{*name}`      catch-all, bracket syntax
+   - anything else  static segment, matched literally"
+  [seg]
+  (cond
+    (str/starts-with? seg ":#")
+    {:type :regex :key (param-key seg) :raw seg}
+
+    (or (str/starts-with? seg "*")
+        (and (str/starts-with? seg "{*") (str/ends-with? seg "}")))
+    {:type :catch-all :key (param-key seg) :raw seg}
+
+    (or (str/starts-with? seg ":")
+        (and (str/starts-with? seg "{") (str/ends-with? seg "}")))
+    {:type :wild :key (param-key seg) :raw seg}
+
+    :else
+    {:type :static :raw seg}))
 
 (defn- ->regex [x]
   (cond
     (regex? x) x
-    (string? x) (string->regex x)))
+    (string? x) (try
+                  (re-pattern x)
+                  (catch #?(:clj Exception :cljs js/Error) _
+                    nil))))
 
-(defn- path-regex [route-data param-key]
-  (let [path-regex (:path-regex route-data)
-        param-value (get path-regex param-key)]
-    (when (contains? path-regex param-key)
-      (->regex param-value))))
+(defn- path-regex-pattern
+  "Resolves the regex pattern string for a `:#name` segment from route-data."
+  [{:keys [key raw]} route-data]
+  (let [path-regex (get route-data :path-regex)
+        param-regex (->regex (get path-regex key))]
+    (when-not param-regex
+      (throw (ex-info (str "Missing path regex for " raw " in " (:name route-data))
+                      {:segment raw
+                       :name (:name route-data)})))
+    (pattern-str param-regex)))
 
-(defn- legacy-path-regex [route-data param-key]
-  (let [param-regex (get-in route-data [:parameters :path param-key])]
-    (when (regex? param-regex)
-      param-regex)))
+(defn- legacy-path-regex-pattern
+  [{:keys [key]} route-data]
+  (when-let [param-regex (->regex (get-in route-data [:parameters :path key]))]
+    (pattern-str param-regex)))
+
+(defn- param-fragment [pattern-string]
+  {:fragment (str "(" pattern-string ")")
+   :inner-groups (count-capturing-groups pattern-string)})
 
 (defn compile-regex-route
-  "Given a route vector [path route-data], returns a map with:
-   - :pattern: a compiled regex pattern built from the path segments,
-   - :group-keys: vector of parameter keys in order,
-   - :route-data: the provided route data,
-   - :result: compiled route result, when provided,
-   - :original-segments: original path segments for path generation,
-   - :template: the original path template for Match objects."
+  "Given a route `[path route-data]` or `[path route-data result]` as produced
+   by reitit's route compilation, returns a map with:
+   - `:pattern`     a compiled regex pattern built from the path segments,
+   - `:params`      vector of `{:key :group :type}` for each parameter segment,
+                    where `:group` is the capture-group index in `:pattern`,
+   - `:segments`    parsed segments, used for path generation,
+   - `:route-data`  the provided route data,
+   - `:result`      the compiled route result threaded through,
+   - `:template`    the original path template for Match objects."
   [[path route-data result]]
-  (let [;; Normalize route-data to ensure it's a map with :name
-        route-data (if (keyword? route-data)
+  (let [route-data (if (keyword? route-data)
                      {:name route-data}
                      route-data)
-
-        ;; Store the original path template for Match objects
         template (if (str/starts-with? path "/")
                    path
                    (str "/" path))
-
-        ;; Handle paths with or without leading slashes
         normalized-path (cond-> path
                                 (str/starts-with? path "/") (subs 1))
-
-        ;; Split into segments, handling empty paths
         segments (if (empty? normalized-path)
                    []
                    (str/split normalized-path #"/"))
+        parsed (mapv parse-segment segments)
+        {:keys [fragments params]}
+        (reduce
+         (fn [{:keys [fragments params group]} {:keys [type key] :as segment}]
+           (case type
+             :static
+             {:fragments (conj fragments (regex-quote (:raw segment)))
+              :params params
+              :group group}
 
-        ;; Store original segments for path generation
-        original-segments segments
+             :wild
+             (if-let [pattern-string (legacy-path-regex-pattern segment route-data)]
+               (let [{:keys [fragment inner-groups]} (param-fragment pattern-string)]
+                 {:fragments (conj fragments fragment)
+                  :params (conj params {:key key :group group :type type})
+                  :group (+ group 1 inner-groups)})
+               {:fragments (conj fragments "([^/]+)")
+                :params (conj params {:key key :group group :type type})
+                :group (inc group)})
 
-        compiled-segments
-        (map (fn [seg]
-               (cond
-                 (regex-param-segment? seg)
-                 (let [param-key (param-key seg)
-                       param-regex (path-regex route-data param-key)]
-                   (when-not param-regex
-                     (throw (ex-info (str "Missing path regex for " seg " in " (:name route-data))
-                                     {:segment seg
-                                      :name (:name route-data)})))
-                   (str "(" (pattern-str param-regex) ")"))
+             :catch-all
+             {:fragments (conj fragments "(.*)")
+              :params (conj params {:key key :group group :type type})
+              :group (inc group)}
 
-                 (param-segment? seg)
-                 (if-let [param-regex (legacy-path-regex route-data (param-key seg))]
-                   (str "(" (pattern-str param-regex) ")")
-                   "([^/]+)")
-
-                 :else
-                 (regex-quote seg)))
-             segments)
-
-        ;; Create the pattern string, handling special case for root path
-        pattern-string (if (empty? segments)
-                         "^/?$"  ;; Match root path with optional trailing slash
-                         (str "^/" (str/join "/" compiled-segments) "$"))
-
-        group-keys (->> segments
-                        (filter param-segment?)
-                        (map param-key)
-                        (vec))]
-
+             :regex
+             (let [{:keys [fragment inner-groups]} (param-fragment (path-regex-pattern segment route-data))]
+               {:fragments (conj fragments fragment)
+                :params (conj params {:key key :group group :type type})
+                :group (+ group 1 inner-groups)})))
+         {:fragments [] :params [] :group 1}
+         parsed)
+        pattern-string (if (empty? parsed)
+                         "^/?$"
+                         (str "^/" (str/join "/" fragments) "$"))]
     {:pattern (re-pattern pattern-string)
-     :group-keys group-keys
+     :params params
+     :segments parsed
      :route-data route-data
      :result result
-     :original-segments original-segments
      :template template}))
 
 (defn- generate-path
-  "Generate a path from a route and path parameters."
-  [route path-params]
-  (if (empty? (:original-segments route))
+  "Generate a path from a compiled route and path parameters."
+  [{:keys [segments]} path-params]
+  (if (empty? segments)
     "/"
     (str "/" (str/join "/"
-                       (map (fn [segment]
-                              (if (param-segment? segment)
-                                (get path-params (param-key segment) "")
-                                segment))
-                            (:original-segments route))))))
+                       (map (fn [{:keys [type key raw]}]
+                              (let [v (impl/into-string (get path-params key ""))]
+                                (case type
+                                  :static raw
+                                  :wild (url-encode-segment v)
+                                  :regex v
+                                  :catch-all (->> (str/split v #"/")
+                                                  (map url-encode-segment)
+                                                  (str/join "/")))))
+                            segments)))))
 
 (defrecord RegexRouter [compiled-routes opts]
   r/Router
   (router-name [_] :regex-router)
 
   (routes [_]
-    (mapv (fn [{:keys [route-data original-segments]}]
-            [(str "/" (str/join "/" original-segments)) route-data])
+    (mapv (fn [{:keys [template route-data]}]
+            [template route-data])
           compiled-routes))
 
   (compiled-routes [_] compiled-routes)
@@ -148,42 +227,44 @@
   (options [_] opts)
 
   (route-names [_]
-    (keep (comp :name :route-data) compiled-routes))
+    (into [] (keep (comp :name :route-data)) compiled-routes))
 
   (match-by-path [_ path]
-    (some (fn [{:keys [pattern group-keys route-data result template]}]
+    (some (fn [{:keys [pattern params route-data result template]}]
             (when-let [matches (re-matches pattern path)]
-              (let [params (zipmap group-keys (rest matches))]
-                (r/->Match template route-data result params path))))
+              (let [matches (if (vector? matches) matches [matches])
+                    path-params (into {}
+                                      (map (fn [{:keys [key group]}]
+                                             [key (impl/url-decode (nth matches group nil))]))
+                                      params)]
+                (r/->Match template route-data result path-params path))))
           compiled-routes))
 
   (match-by-name [this name]
     (r/match-by-name this name {}))
 
-  (match-by-name [router name path-params]
-    (when-let [{:keys [group-keys route-data result template] :as route}
-               (first (filter #(= name (get-in % [:route-data :name])) (r/compiled-routes router)))]
-      ;; Check if all required params are provided
-      (let [required-params (set group-keys)
+  (match-by-name [_ name path-params]
+    (when-let [{:keys [params route-data result template] :as route}
+               (first (filter #(= name (get-in % [:route-data :name])) compiled-routes))]
+      (let [required-params (set (map :key params))
             provided-params (set (keys path-params))]
         (if (every? #(contains? provided-params %) required-params)
-          ;; All required params provided, return a Match
           (let [path (generate-path route path-params)]
             (r/->Match template route-data result path-params path))
-          ;; Some required params missing, return a PartialMatch
           (let [missing (set/difference required-params provided-params)]
             (r/->PartialMatch template route-data result path-params missing)))))))
 
 (defn regex-router
   "Create a RegexRouter from a vector of routes.
-   Each route should be a vector [path route-data]."
+   Each route should be `[path route-data]` or `[path route-data result]`."
   ([routes]
    (regex-router routes {}))
   ([routes opts]
+   ;; Routes are matched linearly in declaration order: first match wins.
    (->RegexRouter (mapv compile-regex-route routes) opts)))
 
 (defn create-regex-router
   "Create a RegexRouter from a vector of routes.
-   Each route should be a vector [path route-data]."
+   Each route should be `[path route-data]`."
   [routes]
   (regex-router routes))

--- a/modules/reitit-core/src/reitit/regex.cljc
+++ b/modules/reitit-core/src/reitit/regex.cljc
@@ -1,16 +1,67 @@
 (ns reitit.regex
   (:require [clojure.set :as set]
             [clojure.string :as str]
-            [reitit.core :as r]))
+            [reitit.core :as r])
+  #?(:clj (:import [java.util.regex Pattern])))
+
+(defn regex?
+  "Returns true if x is a regex pattern in both Clojure and ClojureScript."
+  [x]
+  #?(:clj (instance? Pattern x)
+     :cljs (instance? js/RegExp x)))
+
+(defn pattern-str
+  "Gets the pattern string from a regex in both Clojure and ClojureScript."
+  [regex-obj]
+  #?(:clj (.pattern ^Pattern regex-obj)
+     :cljs (.-source regex-obj)))
+
+(defn regex-quote
+  "Escapes a string for regex in both Clojure and ClojureScript."
+  [s]
+  #?(:clj (Pattern/quote s)
+     :cljs (str/replace s #"[.*+?^${}\(\)|\[\]\\]" "\\$&")))
+
+(defn- regex-param-segment? [segment]
+  (str/starts-with? segment ":#"))
+
+(defn- param-segment? [segment]
+  (str/starts-with? segment ":"))
+
+(defn- param-key [segment]
+  (keyword (subs segment (if (regex-param-segment? segment) 2 1))))
+
+(defn- string->regex [s]
+  (try
+    (re-pattern s)
+    (catch #?(:clj Exception :cljs js/Error) _
+      nil)))
+
+(defn- ->regex [x]
+  (cond
+    (regex? x) x
+    (string? x) (string->regex x)))
+
+(defn- path-regex [route-data param-key]
+  (let [path-regex (:path-regex route-data)
+        param-value (get path-regex param-key)]
+    (when (contains? path-regex param-key)
+      (->regex param-value))))
+
+(defn- legacy-path-regex [route-data param-key]
+  (let [param-regex (get-in route-data [:parameters :path param-key])]
+    (when (regex? param-regex)
+      param-regex)))
 
 (defn compile-regex-route
   "Given a route vector [path route-data], returns a map with:
    - :pattern: a compiled regex pattern built from the path segments,
    - :group-keys: vector of parameter keys in order,
    - :route-data: the provided route data,
+   - :result: compiled route result, when provided,
    - :original-segments: original path segments for path generation,
    - :template: the original path template for Match objects."
-  [[path route-data]]
+  [[path route-data result]]
   (let [;; Normalize route-data to ensure it's a map with :name
         route-data (if (keyword? route-data)
                      {:name route-data}
@@ -35,29 +86,39 @@
 
         compiled-segments
         (map (fn [seg]
-               (if (str/starts-with? seg ":")
-                 (let [param-key   (keyword (subs seg 1))
-                       param-regex (get-in route-data [:parameters :path param-key])]
-                   (if (and param-regex (instance? java.util.regex.Pattern param-regex))
-                     (str "(" (.pattern ^java.util.regex.Pattern param-regex) ")")
-                     ;; Fallback: match any non-slash characters.
-                     "([^/]+)"))
-                 (java.util.regex.Pattern/quote seg)))
+               (cond
+                 (regex-param-segment? seg)
+                 (let [param-key (param-key seg)
+                       param-regex (path-regex route-data param-key)]
+                   (when-not param-regex
+                     (throw (ex-info (str "Missing path regex for " seg " in " (:name route-data))
+                                     {:segment seg
+                                      :name (:name route-data)})))
+                   (str "(" (pattern-str param-regex) ")"))
+
+                 (param-segment? seg)
+                 (if-let [param-regex (legacy-path-regex route-data (param-key seg))]
+                   (str "(" (pattern-str param-regex) ")")
+                   "([^/]+)")
+
+                 :else
+                 (regex-quote seg)))
              segments)
 
         ;; Create the pattern string, handling special case for root path
-        pattern-str (if (empty? segments)
-                      "^/?$"  ;; Match root path with optional trailing slash
-                      (str "^/" (str/join "/" compiled-segments) "$"))
+        pattern-string (if (empty? segments)
+                         "^/?$"  ;; Match root path with optional trailing slash
+                         (str "^/" (str/join "/" compiled-segments) "$"))
 
         group-keys (->> segments
-                        (filter #(str/starts-with? % ":"))
-                        (map #(keyword (subs % 1)))
+                        (filter param-segment?)
+                        (map param-key)
                         (vec))]
 
-    {:pattern    (re-pattern pattern-str)
+    {:pattern (re-pattern pattern-string)
      :group-keys group-keys
      :route-data route-data
+     :result result
      :original-segments original-segments
      :template template}))
 
@@ -68,13 +129,12 @@
     "/"
     (str "/" (str/join "/"
                        (map (fn [segment]
-                              (if (str/starts-with? segment ":")
-                                (let [param-key (keyword (subs segment 1))]
-                                  (get path-params param-key ""))
+                              (if (param-segment? segment)
+                                (get path-params (param-key segment) "")
                                 segment))
                             (:original-segments route))))))
 
-(defrecord RegexRouter [compiled-routes]
+(defrecord RegexRouter [compiled-routes opts]
   r/Router
   (router-name [_] :regex-router)
 
@@ -85,23 +145,23 @@
 
   (compiled-routes [_] compiled-routes)
 
-  (options [_] {})
+  (options [_] opts)
 
   (route-names [_]
     (keep (comp :name :route-data) compiled-routes))
 
   (match-by-path [_ path]
-    (some (fn [{:keys [pattern group-keys route-data template]}]
+    (some (fn [{:keys [pattern group-keys route-data result template]}]
             (when-let [matches (re-matches pattern path)]
               (let [params (zipmap group-keys (rest matches))]
-                (r/->Match template route-data nil params path))))
+                (r/->Match template route-data result params path))))
           compiled-routes))
 
   (match-by-name [this name]
     (r/match-by-name this name {}))
 
   (match-by-name [router name path-params]
-    (when-let [{:keys [group-keys route-data template] :as route}
+    (when-let [{:keys [group-keys route-data result template] :as route}
                (first (filter #(= name (get-in % [:route-data :name])) (r/compiled-routes router)))]
       ;; Check if all required params are provided
       (let [required-params (set group-keys)
@@ -109,13 +169,21 @@
         (if (every? #(contains? provided-params %) required-params)
           ;; All required params provided, return a Match
           (let [path (generate-path route path-params)]
-            (r/->Match template route-data nil path-params path))
+            (r/->Match template route-data result path-params path))
           ;; Some required params missing, return a PartialMatch
           (let [missing (set/difference required-params provided-params)]
-            (r/->PartialMatch template route-data nil path-params missing)))))))
+            (r/->PartialMatch template route-data result path-params missing)))))))
+
+(defn regex-router
+  "Create a RegexRouter from a vector of routes.
+   Each route should be a vector [path route-data]."
+  ([routes]
+   (regex-router routes {}))
+  ([routes opts]
+   (->RegexRouter (mapv compile-regex-route routes) opts)))
 
 (defn create-regex-router
   "Create a RegexRouter from a vector of routes.
    Each route should be a vector [path route-data]."
   [routes]
-  (->RegexRouter (mapv compile-regex-route routes)))
+  (regex-router routes))

--- a/test/cljc/reitit/regex_test.cljc
+++ b/test/cljc/reitit/regex_test.cljc
@@ -1,0 +1,278 @@
+(ns reitit.regex-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [reitit.core :as r]
+            [reitit.regex :as rt.regex]))
+
+(defn re-=
+  "A custom equality function that handles regex patterns specially.
+   Returns true if a and b are equal, with special handling for regex patterns.
+   Also handles comparing records by their map representation."
+  [a b]
+  (cond
+    ;; Handle record comparison by using their map representation
+    (and (instance? clojure.lang.IRecord a)
+         (instance? clojure.lang.IRecord b))
+    (re-= (into {} a) (into {} b))
+
+    ;; If both are regex patterns, compare their string representations
+    (and (instance? java.util.regex.Pattern a)
+         (instance? java.util.regex.Pattern b))
+    (= (str a) (str b))
+
+    ;; If one is a regex and the other isn't, they're not equal
+    (or (instance? java.util.regex.Pattern a)
+        (instance? java.util.regex.Pattern b))
+    false
+
+    ;; For maps, compare each key-value pair using regex-aware-equals
+    (and (map? a) (map? b))
+    (and (= (set (keys a)) (set (keys b)))
+         (every? #(re-= (get a %) (get b %)) (keys a)))
+
+    ;; For sequences, compare each element using regex-aware-equals
+    (and (sequential? a) (sequential? b))
+    (and (= (count a) (count b))
+         (every? identity (map re-= a b)))
+
+    ;; For sets, convert to sequences and compare
+    (and (set? a) (set? b))
+    (re-= (seq a) (seq b))
+
+    ;; For everything else, use regular equality
+    :else
+    (= a b)))
+
+(def routes
+  (rt.regex/create-regex-router
+    [["" ::home]
+     [":item-id" {:name ::item
+                  :parameters {:path {:item-id #"[a-z]{16,20}"}}}]
+     ["inbox" ::inbox]
+     ["teams" ::teams]
+     ["teams/:team-id-b58/members" {:name ::->members
+                                    :parameters {:path {:team-id-b58 #"[a-z]"}}}]]))
+
+(deftest regex-match-by-path-test
+  (testing "Basic path matching"
+    (is (= (r/map->Match {:path "/"
+                          :path-params {}
+                          :data {:name ::home}
+                          :template "/"
+                          :result nil})
+           (r/match-by-path routes "/")))
+
+    (is (= (r/map->Match {:path "/inbox"
+                          :path-params {}
+                          :data {:name ::inbox}
+                          :template "/inbox"
+                          :result nil})
+           (r/match-by-path routes "/inbox")))
+
+    (is (= (r/map->Match {:path "/teams"
+                          :path-params {}
+                          :data {:name ::teams}
+                          :template "/teams"
+                          :result nil})
+           (r/match-by-path routes "/teams"))))
+
+  (testing "Path with regex parameter"
+    (let [valid-id "abcdefghijklmnopq"] ; 17 lowercase letters
+      (is (re-= (r/map->Match {:path (str "/" valid-id)
+                               :path-params {:item-id valid-id}
+                               :data {:name ::item
+                                      :parameters {:path {:item-id #"[a-z]{16,20}"}}},
+                               :template "/:item-id"
+                               :result nil})
+                (r/match-by-path routes (str "/" valid-id)))))
+
+    ;; Invalid parameter cases
+    (is (nil? (r/match-by-path routes "/abcdefg")) "Too short")
+    (is (nil? (r/match-by-path routes "/abcdefghijklmnopqRST")) "Contains uppercase")
+    (is (nil? (r/match-by-path routes "/abcdefghijklmn1234")) "Contains digits"))
+
+  (testing "Nested path with parameter"
+    (is (re-= (r/map->Match {:path "/teams/a/members"
+                             :path-params {:team-id-b58 "a"}
+                             :data {:name ::->members
+                                    :parameters {:path {:team-id-b58 #"[a-z]"}}}
+                             :template "/teams/:team-id-b58/members"
+                             :result nil})
+              (r/match-by-path routes "/teams/a/members")))
+
+    (is (nil? (r/match-by-path routes "/teams/abc/members")) "Multiple characters")
+    (is (nil? (r/match-by-path routes "/teams/1/members")) "Digit instead of letter"))
+
+  (testing "Non-matching paths"
+    (is (nil? (r/match-by-path routes "/unknown")))
+    (is (nil? (r/match-by-path routes "/team"))) ; 'team' not 'teams'
+    (is (nil? (r/match-by-path routes "/teams/extra/segments/here")))))
+
+(deftest regex-match-by-name-test
+  (testing "Basic match-by-name functionality"
+    ;; Root path
+    (is (re-= (r/map->Match {:path "/"
+                             :path-params {}
+                             :data {:name ::home}
+                             :template "/"
+                             :result nil})
+              (r/match-by-name routes ::home)))
+
+    ;; Static paths
+    (is (re-= (r/map->Match {:path "/inbox"
+                             :path-params {}
+                             :data {:name ::inbox}
+                             :template "/inbox"
+                             :result nil})
+              (r/match-by-name routes ::inbox)))
+
+    (is (re-= (r/map->Match {:path "/teams"
+                             :path-params {}
+                             :data {:name ::teams}
+                             :template "/teams"
+                             :result nil})
+              (r/match-by-name routes ::teams)))
+
+    ;; Path with parameter
+    (let [valid-id "abcdefghijklmnopq"]
+      (is (re-= (r/map->Match {:path (str "/" valid-id)
+                               :path-params {:item-id valid-id}
+                               :data {:name ::item
+                                      :parameters {:path {:item-id #"[a-z]{16,20}"}}}
+                               :template "/:item-id"
+                               :result nil})
+                (r/match-by-name routes ::item {:item-id valid-id}))))
+
+    ;; Nested path with parameter
+    (is (re-= (r/map->Match {:path "/teams/a/members"
+                             :path-params {:team-id-b58 "a"}
+                             :data {:name ::->members
+                                    :parameters {:path {:team-id-b58 #"[a-z]"}}}
+                             :template "/teams/:team-id-b58/members"
+                             :result nil})
+              (r/match-by-name routes ::->members {:team-id-b58 "a"}))))
+
+  (testing "Path round-trip matching"
+    ;; Test that paths generated by match-by-name can be successfully matched by match-by-path
+    (let [valid-id "abcdefghijklmnopq"
+          match (r/match-by-name routes ::item {:item-id valid-id})
+          path (:path match)]
+
+      (is (some? path) "Should generate a valid path")
+      (is (re-= match (r/match-by-path routes path))
+          "match-by-path should find the same route that generated the path"))
+
+    (let [match (r/match-by-name routes ::->members {:team-id-b58 "a"})
+          path (:path match)]
+
+      (is (some? path) "Should generate a valid path")
+      (is (re-= match (r/match-by-path routes path))
+          "match-by-path should find the same route that generated the path")))
+
+  (testing "Partial match with missing parameters"
+    ;; Test that routes with missing parameters return PartialMatch
+    (let [partial-match (r/match-by-name routes ::item {})]
+      (is (instance? reitit.core.PartialMatch partial-match)
+          "Should return a PartialMatch when params are missing")
+      (is (= #{:item-id} (:required partial-match))
+          "PartialMatch should indicate the required parameters")
+      (is (re-= (r/map->PartialMatch {:template "/:item-id"
+                                      :data {:name ::item
+                                             :parameters {:path {:item-id #"[a-z]{16,20}"}}}
+                                      :path-params {}
+                                      :required #{:item-id}
+                                      :result nil})
+                partial-match)))
+
+    ;; Test for a nested path with missing parameters
+    (let [partial-match (r/match-by-name routes ::->members {})]
+      (is (instance? reitit.core.PartialMatch partial-match)
+          "Should return a PartialMatch for nested paths too")
+      (is (= #{:team-id-b58} (:required partial-match))
+          "PartialMatch should indicate the required parameters")))
+
+  (testing "Match with invalid parameters"
+    ;; Invalid parameters (that don't match the regex) still produce a Match
+    (let [match (r/match-by-name routes ::item {:item-id "too-short"})
+          path (:path match)]
+
+      (is (instance? reitit.core.Match match)
+          "Should produce a Match even with invalid parameters")
+      (is (= "/too-short" path)
+          "Path should contain the provided parameter value")
+      (is (nil? (r/match-by-path routes path))
+          "Path with invalid parameter shouldn't be matchable by match-by-path")))
+
+  (testing "Non-existent routes"
+    (is (nil? (r/match-by-name routes ::non-existent))
+        "Should return nil for non-existent routes")))
+
+(deftest regex-router-edge-cases-test
+  (testing "Empty router"
+    (let [empty-router (rt.regex/create-regex-router [])]
+      (is (nil? (r/match-by-path empty-router "/any/path")))))
+
+  (testing "Handling trailing slashes"
+    (is (nil? (r/match-by-path routes "/inbox/")))
+
+    (let [router-with-trailing-slash (rt.regex/create-regex-router [["inbox/" ::inbox-with-slash]])]
+      (is (nil? (r/match-by-path router-with-trailing-slash "/inbox/")))
+      (is (some? (r/match-by-path router-with-trailing-slash "/inbox")))))
+
+  (testing "Complex path patterns"
+    (let [complex-router (rt.regex/create-regex-router
+                           [["articles/:year/:month/:slug"
+                             {:name ::article
+                              :parameters {:path {:year #"\d{4}"
+                                                  :month #"\d{2}"
+                                                  :slug #"[a-z0-9\-]+"}}}]
+                            ["files/:path*"
+                             {:name ::file-path}]])]
+
+      ;; Test article route with valid params
+      (let [match (r/match-by-name complex-router ::article
+                                   {:year "2023" :month "02" :slug "test-article"})]
+        (is (instance? reitit.core.Match match)
+            "Should return a Match for complex routes with valid params")
+        (is (= "/articles/2023/02/test-article" (:path match))
+            "Path should be constructed correctly"))
+
+      ;; Test match-by-path with the generated path
+      (let [match (r/match-by-path complex-router "/articles/2023/02/test-article")]
+        (is (some? match)
+            "Should match a valid article path")
+        (is (= {:year "2023", :month "02", :slug "test-article"}
+               (:path-params match))
+            "Should extract all parameters correctly"))
+
+      ;; Test invalid path
+      (is (nil? (r/match-by-path complex-router "/articles/202/02/test-article"))
+          "Should not match an invalid year (3 digits)")
+
+      ;; Test partial params
+      (let [partial-match (r/match-by-name complex-router ::article {:year "2023"})]
+        (is (instance? reitit.core.PartialMatch partial-match)
+            "Should return PartialMatch when some params are missing")
+        (is (= #{:month :slug} (:required partial-match))
+            "Should indicate which params are missing")))))
+
+(deftest custom-router-features-test
+  (testing "Router information access"
+    ;; Test that router information methods work properly
+    (is (= :regex-router (r/router-name routes))
+        "Should return the correct router name")
+
+    (is (seq (r/routes routes))
+        "Should return the list of routes")
+
+    (is (= (set [::home ::item ::inbox ::teams ::->members])
+           (set (r/route-names routes)))
+        "Should return all route names"))
+
+  (testing "Compiled routes access"
+    (let [compiled (r/compiled-routes routes)]
+      (is (seq compiled)
+          "Should return compiled routes")
+      (is (every? :pattern compiled)
+          "Every compiled route should have a pattern")
+      (is (every? :route-data compiled)
+          "Every compiled route should have route data"))))

--- a/test/cljc/reitit/regex_test.cljc
+++ b/test/cljc/reitit/regex_test.cljc
@@ -1,6 +1,8 @@
 (ns reitit.regex-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
+            [reitit.coercion :as coercion]
+            [reitit.coercion.spec :as rss]
             [reitit.core :as r]
             [reitit.regex :as rt.regex]))
 
@@ -14,146 +16,62 @@
        form))
    x))
 
-(defn re-=
-  "A custom equality function that handles regex patterns specially.
-   Returns true if a and b are equal, with special handling for regex patterns.
-   Also handles comparing records by their map representation."
-  [a b]
-  (cond
-    ;; Handle record comparison by using their map representation
-    (and (record? a)
-         (record? b))
-    (re-= (into {} a) (into {} b))
-
-    ;; If both are regex patterns, compare their string representations
-    (and (rt.regex/regex? a)
-         (rt.regex/regex? b))
-    (= (rt.regex/pattern-str a) (rt.regex/pattern-str b))
-
-    ;; If one is a regex and the other isn't, they're not equal
-    (or (rt.regex/regex? a)
-        (rt.regex/regex? b))
-    false
-
-    ;; For maps, compare each key-value pair using regex-aware-equals
-    (and (map? a) (map? b))
-    (and (= (set (keys a)) (set (keys b)))
-         (every? #(re-= (get a %) (get b %)) (keys a)))
-
-    ;; For sequences, compare each element using regex-aware-equals
-    (and (sequential? a) (sequential? b))
-    (and (= (count a) (count b))
-         (every? identity (map re-= a b)))
-
-    ;; For sets, convert to sequences and compare
-    (and (set? a) (set? b))
-    (re-= (seq a) (seq b))
-
-    ;; For everything else, use regular equality
-    :else
-    (= a b)))
-
-(defn process-match [m]
+(defn process-match
+  "Removes data which is not easy to test for equality with."
+  [m]
   (some-> m
-          (update :data dissoc :conflicting)
+          (update :data dissoc :coercion :conflicting)
           re-str))
 
-(def regex-routes
-  [["" ::home]
-   [":#item-id" {:name ::item
-                 :path-regex {:item-id #"[a-z]{16,20}"}}]
-   ["inbox" ::inbox]
-   ["teams" ::teams]
-   ["teams/:#team-id-b58/members" {:name ::->members
-                                   :path-regex {:team-id-b58 #"[a-z]"}}]])
-
-(def routes
-  (rt.regex/create-regex-router regex-routes))
-
-(def core-router
+(def router
   (r/router
    ["/" {:conflicting true}
-    regex-routes]
-   {:router rt.regex/regex-router}))
+    [["" ::home]
+     ["inbox" ::inbox]
+     ["teams" ::teams]
+     [":#item-id" {:name ::item
+                   :path-regex {:item-id #"[a-z]{16,20}"}}]
+     ["teams/:#team-id-b58/members" {:name ::->members
+                                     :path-regex {:team-id-b58 #"[a-z]"}}]
+     ["teams/:#team-id-b58/guests" {:name ::->guests
+                                    :path-regex {:team-id-b58 #"[a-z]"}}]]]
+   {:data {:coercion rss/coercion}
+    :router rt.regex/regex-router}))
 
 (deftest regex-router-test
-  (testing "Compiled regex routes"
-    (is (= :regex-router (r/router-name routes)))
-    (is (= {} (r/options routes)))
+  (is (= :regex-router (r/router-name router)))
+  (is (= rt.regex/regex-router (:router (r/options router))))
 
-    (is (= [{:name ::home
-             :path-regex nil
-             :pattern #?(:clj "^/?$"
-                         :cljs "^\\/?$")}
-            {:name ::item
-             :path-regex {:item-id "[a-z]{16,20}"}
-             :pattern #?(:clj "^/([a-z]{16,20})$"
-                         :cljs "^\\/([a-z]{16,20})$")}
-            {:name ::inbox
-             :path-regex nil
-             :pattern #?(:clj "^/\\Qinbox\\E$"
-                         :cljs "^\\/inbox$")}
-            {:name ::teams
-             :path-regex nil
-             :pattern #?(:clj "^/\\Qteams\\E$"
-                         :cljs "^\\/teams$")}
-            {:name ::->members
-             :path-regex {:team-id-b58 "[a-z]"}
-             :pattern #?(:clj "^/\\Qteams\\E/([a-z])/\\Qmembers\\E$"
-                         :cljs "^\\/teams\\/([a-z])\\/members$")}]
-           (->> (r/compiled-routes routes)
-                (map (fn [route]
-                       {:name (get-in route [:route-data :name])
-                        :path-regex (get-in route [:route-data :path-regex])
-                        :pattern (:pattern route)}))
-                re-str))))
-
-  (testing "Works as a reitit.core/router implementation"
-    (let [valid-id "abcdefghijklmnopq"]
-      (is (= :regex-router (r/router-name core-router)))
-      (is (= rt.regex/regex-router (:router (r/options core-router))))
-      (is (= (r/map->Match {:path (str "/" valid-id)
-                            :path-params {:item-id valid-id}
-                            :data {:name ::item
-                                   :path-regex {:item-id "[a-z]{16,20}"}}
-                            :template "/:#item-id"
-                            :result nil})
-             (process-match (r/match-by-path core-router (str "/" valid-id)))))
-      (is (nil? (r/match-by-path core-router "/inbox/")))))
-
-  (testing "String regex values are supported"
-    (let [router (rt.regex/regex-router
-                  [["strings/:#id" {:name ::string-id
-                                    :path-regex {:id "\\d+"}}]])]
-      (is (= {:id "123"}
-             (:path-params (r/match-by-path router "/strings/123"))))
-      (is (nil? (r/match-by-path router "/strings/abc")))))
-
-  (testing "Regex segments require path regex data"
-    (is (thrown? #?(:clj clojure.lang.ExceptionInfo
-                    :cljs cljs.core.ExceptionInfo)
-                 (rt.regex/regex-router [[":#id" {:name ::missing-regex}]]))))
-
-  (testing "Plain params are unconstrained by :path-regex"
-    (let [router (rt.regex/regex-router
-                  [[":id" {:name ::plain-id
-                           :path-regex {:id #"\d+"}}]])]
-      (is (= {:id "abc"}
-             (:path-params (r/match-by-path router "/abc"))))))
-
-  (testing "Legacy :parameters :path regexes remain supported"
-    (let [router (rt.regex/create-regex-router
-                  [[":id" {:name ::legacy-id
-                           :parameters {:path {:id #"\d+"}}}]])]
-      (is (= {:id "123"}
-             (:path-params (r/match-by-path router "/123"))))
-      (is (nil? (r/match-by-path router "/abc")))))
-
-  (testing "Compiled route results are preserved"
-    (let [router (rt.regex/regex-router
-                  [["result" {:name ::with-result} ::compiled-result]])]
-      (is (= ::compiled-result
-             (:result (r/match-by-path router "/result")))))))
+  (is (= [{:name ::home
+           :path-regex nil
+           :pattern #?(:clj "^/?$"
+                       :cljs "^\\/?$")}
+          {:name ::inbox
+           :path-regex nil
+           :pattern #?(:clj "^/\\Qinbox\\E$"
+                       :cljs "^\\/inbox$")}
+          {:name ::teams
+           :path-regex nil
+           :pattern #?(:clj "^/\\Qteams\\E$"
+                       :cljs "^\\/teams$")}
+          {:name ::item
+           :path-regex {:item-id "[a-z]{16,20}"}
+           :pattern #?(:clj "^/([a-z]{16,20})$"
+                       :cljs "^\\/([a-z]{16,20})$")}
+          {:name ::->members
+           :path-regex {:team-id-b58 "[a-z]"}
+           :pattern #?(:clj "^/\\Qteams\\E/([a-z])/\\Qmembers\\E$"
+                       :cljs "^\\/teams\\/([a-z])\\/members$")}
+          {:name ::->guests
+           :path-regex {:team-id-b58 "[a-z]"}
+           :pattern #?(:clj "^/\\Qteams\\E/([a-z])/\\Qguests\\E$"
+                       :cljs "^\\/teams\\/([a-z])\\/guests$")}]
+         (->> (r/compiled-routes router)
+              (map (fn [route]
+                     {:name (get-in route [:route-data :name])
+                      :path-regex (get-in route [:route-data :path-regex])
+                      :pattern (:pattern route)}))
+              re-str))))
 
 (deftest regex-match-by-path-test
   (testing "Basic path matching"
@@ -162,220 +80,322 @@
                           :data {:name ::home}
                           :template "/"
                           :result nil})
-           (r/match-by-path routes "/")))
+           (process-match (r/match-by-path router "/"))))
 
     (is (= (r/map->Match {:path "/inbox"
                           :path-params {}
                           :data {:name ::inbox}
                           :template "/inbox"
                           :result nil})
-           (r/match-by-path routes "/inbox")))
+           (process-match (r/match-by-path router "/inbox"))))
 
     (is (= (r/map->Match {:path "/teams"
                           :path-params {}
                           :data {:name ::teams}
                           :template "/teams"
                           :result nil})
-           (r/match-by-path routes "/teams"))))
+           (process-match (r/match-by-path router "/teams")))))
 
   (testing "Path with regex parameter"
-    (let [valid-id "abcdefghijklmnopq"] ; 17 lowercase letters
-      (is (re-= (r/map->Match {:path (str "/" valid-id)
-                               :path-params {:item-id valid-id}
-                               :data {:name ::item
-                                      :path-regex {:item-id #"[a-z]{16,20}"}},
-                               :template "/:#item-id"
-                               :result nil})
-                (r/match-by-path routes (str "/" valid-id)))))
+    (let [valid-id "abcdefghijklmnopq"]
+      (is (= (r/map->Match {:path (str "/" valid-id)
+                            :path-params {:item-id valid-id}
+                            :data {:name ::item
+                                   :path-regex {:item-id "[a-z]{16,20}"}}
+                            :template "/:#item-id"
+                            :result nil})
+             (process-match (r/match-by-path router (str "/" valid-id))))))
 
-    ;; Invalid parameter cases
-    (is (nil? (r/match-by-path routes "/abcdefg")) "Too short")
-    (is (nil? (r/match-by-path routes "/abcdefghijklmnopqRST")) "Contains uppercase")
-    (is (nil? (r/match-by-path routes "/abcdefghijklmn1234")) "Contains digits"))
+    (is (nil? (r/match-by-path router "/abcdefg")) "Too short")
+    (is (nil? (r/match-by-path router "/abcdefghijklmnopqRST")) "Contains uppercase")
+    (is (nil? (r/match-by-path router "/abcdefghijklmn1234")) "Contains digits"))
 
   (testing "Nested path with parameter"
-    (is (re-= (r/map->Match {:path "/teams/a/members"
-                             :path-params {:team-id-b58 "a"}
-                             :data {:name ::->members
-                                    :path-regex {:team-id-b58 #"[a-z]"}}
-                             :template "/teams/:#team-id-b58/members"
-                             :result nil})
-              (r/match-by-path routes "/teams/a/members")))
+    (is (= (r/map->Match {:path "/teams/a/members"
+                          :path-params {:team-id-b58 "a"}
+                          :data {:name ::->members
+                                 :path-regex {:team-id-b58 "[a-z]"}}
+                          :template "/teams/:#team-id-b58/members"
+                          :result nil})
+           (process-match (r/match-by-path router "/teams/a/members"))))
 
-    (is (nil? (r/match-by-path routes "/teams/abc/members")) "Multiple characters")
-    (is (nil? (r/match-by-path routes "/teams/1/members")) "Digit instead of letter"))
+    (is (nil? (r/match-by-path router "/teams/abc/members")) "Multiple characters")
+    (is (nil? (r/match-by-path router "/teams/1/members")) "Digit instead of letter"))
 
   (testing "Non-matching paths"
-    (is (nil? (r/match-by-path routes "/unknown")))
-    (is (nil? (r/match-by-path routes "/team"))) ; 'team' not 'teams'
-    (is (nil? (r/match-by-path routes "/teams/extra/segments/here")))))
+    (is (nil? (r/match-by-path router "/unknown")))
+    (is (nil? (r/match-by-path router "/team")))
+    (is (nil? (r/match-by-path router "/teams/extra/segments/here")))))
 
 (deftest regex-match-by-name-test
   (testing "Basic match-by-name functionality"
-    ;; Root path
-    (is (re-= (r/map->Match {:path "/"
-                             :path-params {}
-                             :data {:name ::home}
-                             :template "/"
-                             :result nil})
-              (r/match-by-name routes ::home)))
+    (is (= (r/map->Match {:path "/"
+                          :path-params {}
+                          :data {:name ::home}
+                          :template "/"
+                          :result nil})
+           (process-match (r/match-by-name router ::home))))
 
-    ;; Static paths
-    (is (re-= (r/map->Match {:path "/inbox"
-                             :path-params {}
-                             :data {:name ::inbox}
-                             :template "/inbox"
-                             :result nil})
-              (r/match-by-name routes ::inbox)))
+    (is (= (r/map->Match {:path "/inbox"
+                          :path-params {}
+                          :data {:name ::inbox}
+                          :template "/inbox"
+                          :result nil})
+           (process-match (r/match-by-name router ::inbox))))
 
-    (is (re-= (r/map->Match {:path "/teams"
-                             :path-params {}
-                             :data {:name ::teams}
-                             :template "/teams"
-                             :result nil})
-              (r/match-by-name routes ::teams)))
+    (is (= (r/map->Match {:path "/teams"
+                          :path-params {}
+                          :data {:name ::teams}
+                          :template "/teams"
+                          :result nil})
+           (process-match (r/match-by-name router ::teams))))
 
-    ;; Path with parameter
     (let [valid-id "abcdefghijklmnopq"]
-      (is (re-= (r/map->Match {:path (str "/" valid-id)
-                               :path-params {:item-id valid-id}
-                               :data {:name ::item
-                                      :path-regex {:item-id #"[a-z]{16,20}"}}
-                               :template "/:#item-id"
-                               :result nil})
-                (r/match-by-name routes ::item {:item-id valid-id}))))
+      (is (= (r/map->Match {:path (str "/" valid-id)
+                            :path-params {:item-id valid-id}
+                            :data {:name ::item
+                                   :path-regex {:item-id "[a-z]{16,20}"}}
+                            :template "/:#item-id"
+                            :result nil})
+             (process-match (r/match-by-name router ::item {:item-id valid-id})))))
 
-    ;; Nested path with parameter
-    (is (re-= (r/map->Match {:path "/teams/a/members"
-                             :path-params {:team-id-b58 "a"}
-                             :data {:name ::->members
-                                    :path-regex {:team-id-b58 #"[a-z]"}}
-                             :template "/teams/:#team-id-b58/members"
-                             :result nil})
-              (r/match-by-name routes ::->members {:team-id-b58 "a"}))))
+    (is (= (r/map->Match {:path "/teams/a/members"
+                          :path-params {:team-id-b58 "a"}
+                          :data {:name ::->members
+                                 :path-regex {:team-id-b58 "[a-z]"}}
+                          :template "/teams/:#team-id-b58/members"
+                          :result nil})
+           (process-match (r/match-by-name router ::->members {:team-id-b58 "a"})))))
 
   (testing "Path round-trip matching"
-    ;; Test that paths generated by match-by-name can be successfully matched by match-by-path
     (let [valid-id "abcdefghijklmnopq"
-          match (r/match-by-name routes ::item {:item-id valid-id})
+          match (process-match (r/match-by-name router ::item {:item-id valid-id}))
           path (:path match)]
+      (is (some? path))
+      (is (= match (process-match (r/match-by-path router path)))))
 
-      (is (some? path) "Should generate a valid path")
-      (is (re-= match (r/match-by-path routes path))
-          "match-by-path should find the same route that generated the path"))
-
-    (let [match (r/match-by-name routes ::->members {:team-id-b58 "a"})
+    (let [match (process-match (r/match-by-name router ::->members {:team-id-b58 "a"}))
           path (:path match)]
-
-      (is (some? path) "Should generate a valid path")
-      (is (re-= match (r/match-by-path routes path))
-          "match-by-path should find the same route that generated the path")))
+      (is (some? path))
+      (is (= match (process-match (r/match-by-path router path))))))
 
   (testing "Partial match with missing parameters"
-    ;; Test that routes with missing parameters return PartialMatch
-    (let [partial-match (r/match-by-name routes ::item {})]
-      (is (instance? reitit.core.PartialMatch partial-match)
-          "Should return a PartialMatch when params are missing")
-      (is (= #{:item-id} (:required partial-match))
-          "PartialMatch should indicate the required parameters")
-      (is (re-= (r/map->PartialMatch {:template "/:#item-id"
-                                      :data {:name ::item
-                                             :path-regex {:item-id #"[a-z]{16,20}"}}
-                                      :path-params {}
-                                      :required #{:item-id}
-                                      :result nil})
-                partial-match)))
+    (let [partial-match (process-match (r/match-by-name router ::item {}))]
+      (is (instance? reitit.core.PartialMatch partial-match))
+      (is (= #{:item-id} (:required partial-match)))
+      (is (= (r/map->PartialMatch {:template "/:#item-id"
+                                   :data {:name ::item
+                                          :path-regex {:item-id "[a-z]{16,20}"}}
+                                   :path-params {}
+                                   :required #{:item-id}
+                                   :result nil})
+             partial-match)))
 
-    ;; Test for a nested path with missing parameters
-    (let [partial-match (r/match-by-name routes ::->members {})]
-      (is (instance? reitit.core.PartialMatch partial-match)
-          "Should return a PartialMatch for nested paths too")
-      (is (= #{:team-id-b58} (:required partial-match))
-          "PartialMatch should indicate the required parameters")))
+    (let [partial-match (r/match-by-name router ::->members {})]
+      (is (instance? reitit.core.PartialMatch partial-match))
+      (is (= #{:team-id-b58} (:required partial-match)))))
 
   (testing "Match with invalid parameters"
-    ;; Invalid parameters (that don't match the regex) still produce a Match
-    (let [match (r/match-by-name routes ::item {:item-id "too-short"})
+    (let [match (r/match-by-name router ::item {:item-id "too-short"})
           path (:path match)]
-
-      (is (instance? reitit.core.Match match)
-          "Should produce a Match even with invalid parameters")
-      (is (= "/too-short" path)
-          "Path should contain the provided parameter value")
-      (is (nil? (r/match-by-path routes path))
-          "Path with invalid parameter shouldn't be matchable by match-by-path")))
+      (is (instance? reitit.core.Match match))
+      (is (= "/too-short" path))
+      (is (nil? (r/match-by-path router path)))))
 
   (testing "Non-existent routes"
-    (is (nil? (r/match-by-name routes ::non-existent))
-        "Should return nil for non-existent routes")))
+    (is (nil? (r/match-by-name router ::non-existent)))))
 
 (deftest regex-router-edge-cases-test
   (testing "Empty router"
-    (let [empty-router (rt.regex/create-regex-router [])]
+    (let [empty-router (rt.regex/regex-router [])]
       (is (nil? (r/match-by-path empty-router "/any/path")))))
 
   (testing "Handling trailing slashes"
-    (is (nil? (r/match-by-path routes "/inbox/")))
+    (is (nil? (r/match-by-path router "/inbox/")))
 
-    (let [router-with-trailing-slash (rt.regex/create-regex-router [["inbox/" ::inbox-with-slash]])]
+    (let [router-with-trailing-slash (rt.regex/regex-router [["inbox/" ::inbox-with-slash]])]
       (is (nil? (r/match-by-path router-with-trailing-slash "/inbox/")))
       (is (some? (r/match-by-path router-with-trailing-slash "/inbox")))))
 
   (testing "Complex path patterns"
-    (let [complex-router (rt.regex/create-regex-router
-                           [["articles/:#year/:#month/:#slug"
-                             {:name ::article
-                              :path-regex {:year #"\d{4}"
-                                           :month #"\d{2}"
-                                           :slug #"[a-z0-9\-]+"}}]
-                            ["files/:path*"
-                             {:name ::file-path}]])]
-
-      ;; Test article route with valid params
+    (let [complex-router (rt.regex/regex-router
+                          [["articles/:#year/:#month/:#slug"
+                            {:name ::article
+                             :path-regex {:year #"\d{4}"
+                                          :month #"\d{2}"
+                                          :slug #"[a-z0-9\-]+"}}]
+                           ["files/:path*"
+                            {:name ::file-path}]])]
       (let [match (r/match-by-name complex-router ::article
                                    {:year "2023" :month "02" :slug "test-article"})]
-        (is (instance? reitit.core.Match match)
-            "Should return a Match for complex routes with valid params")
-        (is (= "/articles/2023/02/test-article" (:path match))
-            "Path should be constructed correctly"))
+        (is (instance? reitit.core.Match match))
+        (is (= "/articles/2023/02/test-article" (:path match))))
 
-      ;; Test match-by-path with the generated path
       (let [match (r/match-by-path complex-router "/articles/2023/02/test-article")]
-        (is (some? match)
-            "Should match a valid article path")
+        (is (some? match))
         (is (= {:year "2023", :month "02", :slug "test-article"}
-               (:path-params match))
-            "Should extract all parameters correctly"))
+               (:path-params match))))
 
-      ;; Test invalid path
-      (is (nil? (r/match-by-path complex-router "/articles/202/02/test-article"))
-          "Should not match an invalid year (3 digits)")
+      (is (nil? (r/match-by-path complex-router "/articles/202/02/test-article")))
 
-      ;; Test partial params
       (let [partial-match (r/match-by-name complex-router ::article {:year "2023"})]
-        (is (instance? reitit.core.PartialMatch partial-match)
-            "Should return PartialMatch when some params are missing")
-        (is (= #{:month :slug} (:required partial-match))
-            "Should indicate which params are missing")))))
+        (is (instance? reitit.core.PartialMatch partial-match))
+        (is (= #{:month :slug} (:required partial-match)))))))
 
 (deftest custom-router-features-test
   (testing "Router information access"
-    ;; Test that router information methods work properly
-    (is (= :regex-router (r/router-name routes))
-        "Should return the correct router name")
-
-    (is (seq (r/routes routes))
-        "Should return the list of routes")
-
-    (is (= (set [::home ::item ::inbox ::teams ::->members])
-           (set (r/route-names routes)))
-        "Should return all route names"))
+    (is (= :regex-router (r/router-name router)))
+    (is (seq (r/routes router)))
+    (is (= #{::home ::item ::inbox ::teams ::->members ::->guests}
+           (set (r/route-names router)))))
 
   (testing "Compiled routes access"
-    (let [compiled (r/compiled-routes routes)]
-      (is (seq compiled)
-          "Should return compiled routes")
-      (is (every? :pattern compiled)
-          "Every compiled route should have a pattern")
-      (is (every? :route-data compiled)
-          "Every compiled route should have route data"))))
+    (let [compiled (r/compiled-routes router)]
+      (is (seq compiled))
+      (is (every? :pattern compiled))
+      (is (every? :route-data compiled)))))
+
+(deftest result-threading-test
+  (let [coercion-router (r/router
+                         [["/users/:id" {:name ::user
+                                         :parameters {:path {:id int?}}}]]
+                         {:data {:coercion rss/coercion}
+                          :compile coercion/compile-request-coercers
+                          :router rt.regex/regex-router})]
+    (testing "compiled :result is threaded through to matches so coercion works"
+      (let [match (r/match-by-path coercion-router "/users/42")]
+        (is (some? (:result match)))
+        (is (= {:path {:id 42}}
+               (coercion/coerce! match)))))
+
+    (testing "match-by-name also carries :result"
+      (is (some? (:result (r/match-by-name coercion-router ::user {:id 7})))))))
+
+(deftest nested-capture-groups-test
+  (testing "user regex capturing groups do not desync params"
+    (let [router (rt.regex/regex-router
+                  [["/post/:#kind" {:name ::post
+                                    :path-regex {:kind #"(news|blog)-\d+"}}]
+                   ["/x/:#a/:#b" {:name ::two
+                                  :path-regex {:a #"(foo|bar)"
+                                               :b #"\d+"}}]])]
+      (is (= {:kind "news-42"}
+             (:path-params (r/match-by-path router "/post/news-42"))))
+      (is (= {:a "foo" :b "123"}
+             (:path-params (r/match-by-path router "/x/foo/123"))))
+      (is (nil? (r/match-by-path router "/x/baz/123"))))))
+
+(deftest url-encoding-test
+  (let [router (rt.regex/regex-router
+                [["/:slug" {:name ::slug}]
+                 ["/files/*path" {:name ::files}]])]
+    (testing "path params are URL-decoded on match"
+      (is (= {:slug "hello world"}
+             (:path-params (r/match-by-path router "/hello%20world")))))
+
+    (testing "param values are URL-encoded when generating a path"
+      (is (= "/a%20b%2Fc"
+             (:path (r/match-by-name router ::slug {:slug "a b/c"})))))
+
+    (testing "catch-all values are encoded per segment, preserving slashes"
+      (is (= "/files/a%20b/c%20d"
+             (:path (r/match-by-name router ::files {:path "a b/c d"})))))
+
+    (testing "name to path to match round-trips through encoding"
+      (let [path (:path (r/match-by-name router ::slug {:slug "a b"}))]
+        (is (= "/a%20b" path))
+        (is (= {:slug "a b"} (:path-params (r/match-by-path router path)))))
+      (let [path (:path (r/match-by-name router ::files {:path "x/y z"}))]
+        (is (= "/files/x/y%20z" path))
+        (is (= {:path "x/y z"} (:path-params (r/match-by-path router path)))))))
+
+  (testing "a :# regex param's value is emitted verbatim"
+    (let [router (rt.regex/regex-router
+                  [["/components/:#component-id"
+                    {:name ::component
+                     :path-regex {:component-id #"[0-9a-zA-Z-/]+"}}]])]
+      (is (= "/components/fancy/input"
+             (:path (r/match-by-name router ::component {:component-id "fancy/input"}))))
+      (let [path (:path (r/match-by-name router ::component {:component-id "fancy/input"}))]
+        (is (= {:component-id "fancy/input"}
+               (:path-params (r/match-by-path router path))))))))
+
+(deftest linear-matching-test
+  (testing "matching is linear and first-match-wins, in declaration order"
+    (let [router (rt.regex/regex-router
+                  [["/inbox" {:name ::inbox}]
+                   ["/special" {:name ::special}]
+                   ["/:slug" {:name ::slug}]])]
+      (is (= ::inbox (-> (r/match-by-path router "/inbox") :data :name)))
+      (is (= ::special (-> (r/match-by-path router "/special") :data :name)))
+      (is (= ::slug (-> (r/match-by-path router "/anything-else") :data :name)))))
+
+  (testing "a broad route declared first shadows later, more specific routes"
+    (let [router (rt.regex/regex-router
+                  [["/:slug" {:name ::slug}]
+                   ["/inbox" {:name ::inbox}]])]
+      (is (= ::slug (-> (r/match-by-path router "/inbox") :data :name)))))
+
+  (testing "catch-all declared after explicit routes lets the explicit route win"
+    (let [router (rt.regex/regex-router
+                  [["/files/:a/:b" {:name ::explicit}]
+                   ["/files/*path" {:name ::catch-all}]])]
+      (is (= ::explicit (-> (r/match-by-path router "/files/x/y") :data :name)))
+      (is (= ::catch-all (-> (r/match-by-path router "/files/x/y/z") :data :name))))))
+
+(deftest catch-all-test
+  (let [router (rt.regex/regex-router
+                [["/files/*path" {:name ::files}]
+                 ["/c/{*rest}" {:name ::bracket-catch}]])]
+    (testing "*name catch-all matches the remainder of the path including slashes"
+      (is (= {:path "a/b/c.txt"}
+             (:path-params (r/match-by-path router "/files/a/b/c.txt"))))
+      (is (= ::files (-> (r/match-by-path router "/files/a/b/c.txt") :data :name))))
+
+    (testing "{*name} bracket catch-all is equivalent"
+      (is (= {:rest "x/y/z"}
+             (:path-params (r/match-by-path router "/c/x/y/z")))))
+
+    (testing "catch-all matches a single trailing segment"
+      (is (= {:path "readme"}
+             (:path-params (r/match-by-path router "/files/readme")))))))
+
+(deftest bracket-syntax-test
+  (testing "{param} is treated as a wildcard segment, like :param"
+    (let [router (rt.regex/regex-router
+                  [["/u/{id}" {:name ::user}]
+                   ["/u/{id}/posts" {:name ::posts}]])]
+      (is (= {:id "99"}
+             (:path-params (r/match-by-path router "/u/99"))))
+      (is (= {:id "99"}
+             (:path-params (r/match-by-path router "/u/99/posts"))))
+      (is (= "/u/abc" (:path (r/match-by-name router ::user {:id "abc"})))))))
+
+(deftest compatibility-test
+  (testing "create-regex-router remains as a compatibility wrapper"
+    (let [router (rt.regex/create-regex-router
+                  [["strings/:#id" {:name ::string-id
+                                    :path-regex {:id "\\d+"}}]])]
+      (is (= {:id "123"}
+             (:path-params (r/match-by-path router "/strings/123"))))
+      (is (nil? (r/match-by-path router "/strings/abc")))))
+
+  (testing "regex segments require path regex data"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo
+                    :cljs cljs.core.ExceptionInfo)
+                 (rt.regex/regex-router [[":#id" {:name ::missing-regex}]]))))
+
+  (testing "plain params are unconstrained by :path-regex"
+    (let [router (rt.regex/regex-router
+                  [[":id" {:name ::plain-id
+                           :path-regex {:id #"\d+"}}]])]
+      (is (= {:id "abc"}
+             (:path-params (r/match-by-path router "/abc"))))))
+
+  (testing "legacy :parameters :path regexes remain supported"
+    (let [router (rt.regex/create-regex-router
+                  [[":id" {:name ::legacy-id
+                           :parameters {:path {:id #"\d+"}}}]])]
+      (is (= {:id "123"}
+             (:path-params (r/match-by-path router "/123"))))
+      (is (nil? (r/match-by-path router "/abc"))))))

--- a/test/cljc/reitit/regex_test.cljc
+++ b/test/cljc/reitit/regex_test.cljc
@@ -1,7 +1,18 @@
 (ns reitit.regex-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [reitit.core :as r]
             [reitit.regex :as rt.regex]))
+
+(defn re-str
+  "Walks a data structure to convert any regex to its string representation."
+  [x]
+  (walk/postwalk
+   (fn [form]
+     (if (rt.regex/regex? form)
+       (rt.regex/pattern-str form)
+       form))
+   x))
 
 (defn re-=
   "A custom equality function that handles regex patterns specially.
@@ -10,18 +21,18 @@
   [a b]
   (cond
     ;; Handle record comparison by using their map representation
-    (and (instance? clojure.lang.IRecord a)
-         (instance? clojure.lang.IRecord b))
+    (and (record? a)
+         (record? b))
     (re-= (into {} a) (into {} b))
 
     ;; If both are regex patterns, compare their string representations
-    (and (instance? java.util.regex.Pattern a)
-         (instance? java.util.regex.Pattern b))
-    (= (str a) (str b))
+    (and (rt.regex/regex? a)
+         (rt.regex/regex? b))
+    (= (rt.regex/pattern-str a) (rt.regex/pattern-str b))
 
     ;; If one is a regex and the other isn't, they're not equal
-    (or (instance? java.util.regex.Pattern a)
-        (instance? java.util.regex.Pattern b))
+    (or (rt.regex/regex? a)
+        (rt.regex/regex? b))
     false
 
     ;; For maps, compare each key-value pair using regex-aware-equals
@@ -42,15 +53,107 @@
     :else
     (= a b)))
 
+(defn process-match [m]
+  (some-> m
+          (update :data dissoc :conflicting)
+          re-str))
+
+(def regex-routes
+  [["" ::home]
+   [":#item-id" {:name ::item
+                 :path-regex {:item-id #"[a-z]{16,20}"}}]
+   ["inbox" ::inbox]
+   ["teams" ::teams]
+   ["teams/:#team-id-b58/members" {:name ::->members
+                                   :path-regex {:team-id-b58 #"[a-z]"}}]])
+
 (def routes
-  (rt.regex/create-regex-router
-    [["" ::home]
-     [":item-id" {:name ::item
-                  :parameters {:path {:item-id #"[a-z]{16,20}"}}}]
-     ["inbox" ::inbox]
-     ["teams" ::teams]
-     ["teams/:team-id-b58/members" {:name ::->members
-                                    :parameters {:path {:team-id-b58 #"[a-z]"}}}]]))
+  (rt.regex/create-regex-router regex-routes))
+
+(def core-router
+  (r/router
+   ["/" {:conflicting true}
+    regex-routes]
+   {:router rt.regex/regex-router}))
+
+(deftest regex-router-test
+  (testing "Compiled regex routes"
+    (is (= :regex-router (r/router-name routes)))
+    (is (= {} (r/options routes)))
+
+    (is (= [{:name ::home
+             :path-regex nil
+             :pattern #?(:clj "^/?$"
+                         :cljs "^\\/?$")}
+            {:name ::item
+             :path-regex {:item-id "[a-z]{16,20}"}
+             :pattern #?(:clj "^/([a-z]{16,20})$"
+                         :cljs "^\\/([a-z]{16,20})$")}
+            {:name ::inbox
+             :path-regex nil
+             :pattern #?(:clj "^/\\Qinbox\\E$"
+                         :cljs "^\\/inbox$")}
+            {:name ::teams
+             :path-regex nil
+             :pattern #?(:clj "^/\\Qteams\\E$"
+                         :cljs "^\\/teams$")}
+            {:name ::->members
+             :path-regex {:team-id-b58 "[a-z]"}
+             :pattern #?(:clj "^/\\Qteams\\E/([a-z])/\\Qmembers\\E$"
+                         :cljs "^\\/teams\\/([a-z])\\/members$")}]
+           (->> (r/compiled-routes routes)
+                (map (fn [route]
+                       {:name (get-in route [:route-data :name])
+                        :path-regex (get-in route [:route-data :path-regex])
+                        :pattern (:pattern route)}))
+                re-str))))
+
+  (testing "Works as a reitit.core/router implementation"
+    (let [valid-id "abcdefghijklmnopq"]
+      (is (= :regex-router (r/router-name core-router)))
+      (is (= rt.regex/regex-router (:router (r/options core-router))))
+      (is (= (r/map->Match {:path (str "/" valid-id)
+                            :path-params {:item-id valid-id}
+                            :data {:name ::item
+                                   :path-regex {:item-id "[a-z]{16,20}"}}
+                            :template "/:#item-id"
+                            :result nil})
+             (process-match (r/match-by-path core-router (str "/" valid-id)))))
+      (is (nil? (r/match-by-path core-router "/inbox/")))))
+
+  (testing "String regex values are supported"
+    (let [router (rt.regex/regex-router
+                  [["strings/:#id" {:name ::string-id
+                                    :path-regex {:id "\\d+"}}]])]
+      (is (= {:id "123"}
+             (:path-params (r/match-by-path router "/strings/123"))))
+      (is (nil? (r/match-by-path router "/strings/abc")))))
+
+  (testing "Regex segments require path regex data"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo
+                    :cljs cljs.core.ExceptionInfo)
+                 (rt.regex/regex-router [[":#id" {:name ::missing-regex}]]))))
+
+  (testing "Plain params are unconstrained by :path-regex"
+    (let [router (rt.regex/regex-router
+                  [[":id" {:name ::plain-id
+                           :path-regex {:id #"\d+"}}]])]
+      (is (= {:id "abc"}
+             (:path-params (r/match-by-path router "/abc"))))))
+
+  (testing "Legacy :parameters :path regexes remain supported"
+    (let [router (rt.regex/create-regex-router
+                  [[":id" {:name ::legacy-id
+                           :parameters {:path {:id #"\d+"}}}]])]
+      (is (= {:id "123"}
+             (:path-params (r/match-by-path router "/123"))))
+      (is (nil? (r/match-by-path router "/abc")))))
+
+  (testing "Compiled route results are preserved"
+    (let [router (rt.regex/regex-router
+                  [["result" {:name ::with-result} ::compiled-result]])]
+      (is (= ::compiled-result
+             (:result (r/match-by-path router "/result")))))))
 
 (deftest regex-match-by-path-test
   (testing "Basic path matching"
@@ -80,8 +183,8 @@
       (is (re-= (r/map->Match {:path (str "/" valid-id)
                                :path-params {:item-id valid-id}
                                :data {:name ::item
-                                      :parameters {:path {:item-id #"[a-z]{16,20}"}}},
-                               :template "/:item-id"
+                                      :path-regex {:item-id #"[a-z]{16,20}"}},
+                               :template "/:#item-id"
                                :result nil})
                 (r/match-by-path routes (str "/" valid-id)))))
 
@@ -94,8 +197,8 @@
     (is (re-= (r/map->Match {:path "/teams/a/members"
                              :path-params {:team-id-b58 "a"}
                              :data {:name ::->members
-                                    :parameters {:path {:team-id-b58 #"[a-z]"}}}
-                             :template "/teams/:team-id-b58/members"
+                                    :path-regex {:team-id-b58 #"[a-z]"}}
+                             :template "/teams/:#team-id-b58/members"
                              :result nil})
               (r/match-by-path routes "/teams/a/members")))
 
@@ -137,8 +240,8 @@
       (is (re-= (r/map->Match {:path (str "/" valid-id)
                                :path-params {:item-id valid-id}
                                :data {:name ::item
-                                      :parameters {:path {:item-id #"[a-z]{16,20}"}}}
-                               :template "/:item-id"
+                                      :path-regex {:item-id #"[a-z]{16,20}"}}
+                               :template "/:#item-id"
                                :result nil})
                 (r/match-by-name routes ::item {:item-id valid-id}))))
 
@@ -146,8 +249,8 @@
     (is (re-= (r/map->Match {:path "/teams/a/members"
                              :path-params {:team-id-b58 "a"}
                              :data {:name ::->members
-                                    :parameters {:path {:team-id-b58 #"[a-z]"}}}
-                             :template "/teams/:team-id-b58/members"
+                                    :path-regex {:team-id-b58 #"[a-z]"}}
+                             :template "/teams/:#team-id-b58/members"
                              :result nil})
               (r/match-by-name routes ::->members {:team-id-b58 "a"}))))
 
@@ -175,9 +278,9 @@
           "Should return a PartialMatch when params are missing")
       (is (= #{:item-id} (:required partial-match))
           "PartialMatch should indicate the required parameters")
-      (is (re-= (r/map->PartialMatch {:template "/:item-id"
+      (is (re-= (r/map->PartialMatch {:template "/:#item-id"
                                       :data {:name ::item
-                                             :parameters {:path {:item-id #"[a-z]{16,20}"}}}
+                                             :path-regex {:item-id #"[a-z]{16,20}"}}
                                       :path-params {}
                                       :required #{:item-id}
                                       :result nil})
@@ -220,11 +323,11 @@
 
   (testing "Complex path patterns"
     (let [complex-router (rt.regex/create-regex-router
-                           [["articles/:year/:month/:slug"
+                           [["articles/:#year/:#month/:#slug"
                              {:name ::article
-                              :parameters {:path {:year #"\d{4}"
-                                                  :month #"\d{2}"
-                                                  :slug #"[a-z0-9\-]+"}}}]
+                              :path-regex {:year #"\d{4}"
+                                           :month #"\d{2}"
+                                           :slug #"[a-z0-9\-]+"}}]
                             ["files/:path*"
                              {:name ::file-path}]])]
 

--- a/test/cljs/reitit/doo_runner.cljs
+++ b/test/cljs/reitit/doo_runner.cljs
@@ -4,6 +4,7 @@
             reitit.core-test
             reitit.impl-test
             reitit.middleware-test
+            reitit.regex-test
             reitit.ring-test
             reitit.spec-test
             reitit.exception-test
@@ -18,6 +19,7 @@
            'reitit.core-test
            'reitit.impl-test
            'reitit.middleware-test
+           'reitit.regex-test
            'reitit.ring-test
            'reitit.spec-test
            'reitit.exception-test


### PR DESCRIPTION
Reitit is very fast, but cannot support all routing structures that other routers like Bidi support, particular regex-based routes.

This PR is a proof of concept of one way that a regex based router could work with Reitit.

A more complete version of this PR would compile only the regex based routes to this router, and let the rest of the routes be handled by faster Reitit routers. You could also compile the regex based router to match on a path segment at a time, pruning routes before needing to evaluate a regular expression.

Before I go too much further, I wanted to get some feedback on the syntax for route definition and the overall approach. What do you think about this idea, and the way that path parameters are defined as regex's?

This unoptimized router is about 8-20x slower than regular Reitit in some informal testing.

Fixes https://github.com/metosin/reitit/issues/722
