### PR TITLE
malli now uses . instead of ~1 in json-schema/swagger $refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 * **BREAKING** Fix & clarify `:responses :default` and `:content :default` handling. See [docs](./doc/ring/coercion.md). [#735](https://github.com/metosin/reitit/pull/735)
   * Summary: If `:responses <status>` is present, `:responses :default` is not used, even if `:responses <status>` defines no schema.
   * Should not break normal use, but might cause surprises related to defaults applying/not applying
+* **NOTE** This release depends on malli 0.18.0, which changes the format of OpenAPI & Swagger named schemas from `foo.bar/quux` to `foo.bar.quux`
 
 ## 0.8.0 (2025-03-28)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "shadow-cljs": "^2.28.22"
       },
       "devDependencies": {
-        "@seriousme/openapi-schema-validator": "^2.3.1",
+        "@seriousme/openapi-schema-validator": "^2.4.0",
         "karma": "^6.4.4",
         "karma-chrome-launcher": "^3.2.0",
         "karma-cli": "^2.0.0",
@@ -27,11 +27,10 @@
       }
     },
     "node_modules/@seriousme/openapi-schema-validator": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.3.1.tgz",
-      "integrity": "sha512-szUXBZJUhq+Yw+vUro2QeltSIoZvMDQi3MLqJhIKcRcRYyFt9B6dyjMD1RVf3nFvNAHkWqa48NJA46ti2P8smA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.4.0.tgz",
+      "integrity": "sha512-2PWq2QbDMu+CANpBLZ2Uch9PgTIiftLpiLH4lcaykjV463f4Vt9eD61EeaVI++D0HII4JKnptX46391pII1XZA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reitit",
   "private": true,
   "devDependencies": {
-    "@seriousme/openapi-schema-validator": "^2.3.1",
+    "@seriousme/openapi-schema-validator": "^2.4.0",
     "karma": "^6.4.4",
     "karma-chrome-launcher": "^3.2.0",
     "karma-cli": "^2.0.0",

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                          [metosin/muuntaja "0.6.11"]
                          [metosin/jsonista "0.3.13"]
                          [metosin/sieppari "0.0.0-alpha13"]
-                         [metosin/malli "0.17.0"]
+                         [metosin/malli "0.18.0"]
 
                          ;; https://clojureverse.org/t/depending-on-the-right-versions-of-jackson-libraries/5111
                          [com.fasterxml.jackson.core/jackson-core "2.18.2"]
@@ -99,7 +99,7 @@
                                   [metosin/muuntaja "0.6.11"]
                                   [metosin/sieppari "0.0.0-alpha13"]
                                   [metosin/jsonista "0.3.13"]
-                                  [metosin/malli "0.17.0"]
+                                  [metosin/malli "0.18.0"]
                                   [lambdaisland/deep-diff "0.0-47"]
                                   [meta-merge "1.0.0"]
                                   [com.bhauman/spell-spec "0.1.2"]

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -1009,7 +1009,7 @@
                  {:content
                   {"application/json"
                    {:schema
-                    {:$ref "#/components/schemas/reitit.openapi-test~1Plus"}}}}}}
+                    {:$ref "#/components/schemas/reitit.openapi-test.Plus"}}}}}}
                "/get"
                {:get
                 {:parameters
@@ -1019,19 +1019,15 @@
                   {:in "query"
                    :name :y
                    :required true
-                   :schema {:$ref "#/components/schemas/reitit.openapi-test~1Y"}}]}}}
+                   :schema {:$ref "#/components/schemas/reitit.openapi-test.Y"}}]}}}
               :components
               {:schemas
-               {"reitit.openapi-test/Plus"
+               {"reitit.openapi-test.Plus"
                 {:type "object"
                  :properties
                  {:x {:type "integer"}
-                  :y {:$ref "#/components/schemas/reitit.openapi-test~1Y"}}
+                  :y {:$ref "#/components/schemas/reitit.openapi-test.Y"}}
                  :required [:x :y]}
-                "reitit.openapi-test/Y" {:type "integer"}}}}
+                "reitit.openapi-test.Y" {:type "integer"}}}}
              spec))
-      ;; TODO: the OAS 3.1 json schema disallows "/" in :components :schemas keys,
-      ;; even though the text of the spec allows it. See:
-      ;; https://github.com/seriousme/openapi-schema-validator/blob/772375bf4895f0e641d103c27140cdd1d2afc34e/schemas/v3.1/schema.json#L282
-      #_
       (is (nil? (validate spec))))))

--- a/test/cljc/reitit/swagger_test.clj
+++ b/test/cljc/reitit/swagger_test.clj
@@ -161,14 +161,14 @@
           expected {:x-id #{::math}
                     :swagger "2.0"
                     :info {:title "my-api"}
-                    :definitions {"reitit.swagger-test/req-key" {:type "string"
+                    :definitions {"reitit.swagger-test.req-key" {:type "string"
                                              :x-anyOf [{:type "string"}
                                                        {:type "string"}]}
-                                  "reitit.swagger-test/req-val" {:type "object"
+                                  "reitit.swagger-test.req-val" {:type "object"
                                              :x-anyOf [{:type "object"}
                                                        {:type "string"}]}
-                                  "reitit.swagger-test/resp-map" {:type "object"},
-                                  "reitit.swagger-test/resp-string" {:type "string"
+                                  "reitit.swagger-test.resp-map" {:type "object"},
+                                  "reitit.swagger-test.resp-string" {:type "string"
                                                  :minLength 1}}
                     :paths {"/api/spec/plus/{z}" {:patch {:parameters []
                                                           :summary "patch"
@@ -287,12 +287,12 @@
                                                                        :schema
                                                                        {:type "object"
                                                                         :additionalProperties
-                                                                        {:$ref "#/definitions/reitit.swagger-test~1req-val"}}}]
+                                                                        {:$ref "#/definitions/reitit.swagger-test.req-val"}}}]
                                                          :responses {200
                                                                      {:schema
-                                                                      {:$ref "#/definitions/reitit.swagger-test~1resp-map"
-                                                                       :x-anyOf [{:$ref "#/definitions/reitit.swagger-test~1resp-map"}
-                                                                                 {:$ref "#/definitions/reitit.swagger-test~1resp-string"}]}
+                                                                      {:$ref "#/definitions/reitit.swagger-test.resp-map"
+                                                                       :x-anyOf [{:$ref "#/definitions/reitit.swagger-test.resp-map"}
+                                                                                 {:$ref "#/definitions/reitit.swagger-test.resp-string"}]}
                                                                       :description ""}
                                                                      500 {:description "fail"}}
                                                          :summary "plus put with definitions"}}
@@ -532,24 +532,24 @@
                 {:get {:no-doc true
                        :handler (swagger/create-swagger-handler)}}]]))
         spec (:body (app {:request-method :get, :uri "/swagger.json"}))]
-    (is (= {:definitions {"reitit.swagger-test/Plus" {:properties {:x {:$ref "#/definitions/reitit.swagger-test~1X"},
-                                                                   :y {:$ref "#/definitions/reitit.swagger-test~1Y"}},
+    (is (= {:definitions {"reitit.swagger-test.Plus" {:properties {:x {:$ref "#/definitions/reitit.swagger-test.X"},
+                                                                   :y {:$ref "#/definitions/reitit.swagger-test.Y"}},
                                                       :required [:x :y],
                                                       :type "object"},
-                          "reitit.swagger-test/X" {:format "int64",
+                          "reitit.swagger-test.X" {:format "int64",
                                                    :type "integer"},
-                          "reitit.swagger-test/Y" {:format "int64",
+                          "reitit.swagger-test.Y" {:format "int64",
                                                    :type "integer"},
-                          "reitit.swagger-test/Result" {:type "object",
+                          "reitit.swagger-test.Result" {:type "object",
                                                         :properties {:result {:type "integer", :format "int64"}},
                                                         :required [:result]}},
             :paths {"/post" {:post {:parameters [{:description "",
                                                   :in "body",
                                                   :name "body",
                                                   :required true,
-                                                  :schema {:$ref "#/definitions/reitit.swagger-test~1Plus"}}]
+                                                  :schema {:$ref "#/definitions/reitit.swagger-test.Plus"}}]
                                     :responses {200 {:description ""
-                                                     :schema {:$ref "#/definitions/reitit.swagger-test~1Result"}}}}}
+                                                     :schema {:$ref "#/definitions/reitit.swagger-test.Result"}}}}}
                     "/get" {:get {:parameters [{:in "query"
                                                 :name :x
                                                 :description ""
@@ -563,7 +563,7 @@
                                                 :required true
                                                 :format "int64"}]
                                   :responses {200 {:description ""
-                                                   :schema {:$ref "#/definitions/reitit.swagger-test~1Result"}}}}}}
+                                                   :schema {:$ref "#/definitions/reitit.swagger-test.Result"}}}}}}
             :swagger "2.0",
             :x-id #{:reitit.swagger/default}}
            spec))))


### PR DESCRIPTION
these are the test fixes needed once metosin/malli#1183 is released

also bump openapi-schema-validator while at it