### PR TITLE
Add test-doc-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ Reitit is tested with the LTS releases Java 11, 17, 21 and 25
     [["/api/ping" ::ping]
      ["/api/orders/:id" ::order]]))
 
-(into {} (r/match-by-path router "/api/ping"))
+(r/match-by-path router "/api/ping")
 ;; => {:template "/api/ping"
 ;;     :data {:name ::ping}
 ;;     :result nil
 ;;     :path-params {}
 ;;     :path "/api/ping"}
 
-(into {} (r/match-by-name router ::order {:id 2}))
+(r/match-by-name router ::order {:id 2})
 ;; => {:template "/api/orders/:id",
 ;;     :data {:name ::order},
 ;;     :result nil,
@@ -147,25 +147,24 @@ Valid request:
 
 Invalid request:
 
-<!-- FIXME: Not asserted because each run gets a new generated spec name -->
 ```clj
 (-> (app {:request-method :get
           :uri "/api/math"
           :query-params {:x "1", :y "a"}})
     (update :body jsonista.core/read-value))
-;; {:status 400
-;;  :headers {"Content-Type" "application/json; charset=utf-8"}
-;;  :body {"spec" "(spec-tools.core/spec {:spec (clojure.spec.alpha/keys :req-un [:spec$8974/x :spec$8974/y]), :type :map, :leaf? false})"
-;;         "value" {"x" "1"
-;;                  "y" "a"}
-;;         "problems" [{"via" ["spec$8974/y"]
-;;                      "path" ["y"]
-;;                      "pred" "clojure.core/int?"
-;;                      "in" ["y"]
-;;                      "val" "a"}]
-;;         "type" "reitit.coercion/request-coercion"
-;;         "coercion" "spec"
-;;         "in" ["request" "query-params"]}}
+;; => {:status 400
+;;     :headers {"Content-Type" "application/json; charset=utf-8"}
+;;     :body {"spec" ...
+;;            "value" {"x" "1"
+;;                     "y" "a"}
+;;            "problems" [{"via" [...]
+;;                         "path" ["y"]
+;;                         "pred" "clojure.core/int?"
+;;                         "in" ["y"]
+;;                         "val" "a"}]
+;;            "type" "reitit.coercion/request-coercion"
+;;            "coercion" "spec"
+;;            "in" ["request" "query-params"]}}
 ```
 
 ## More examples

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ modules will continue to be released under `metosin` for compatibility purposes.
 
 All main modules bundled:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit "0.10.1"]
 ```
@@ -83,21 +84,21 @@ Reitit is tested with the LTS releases Java 11, 17, 21 and 25
 (def router
   (r/router
     [["/api/ping" ::ping]
-     ["/api/orders/:id" ::order]]))
+     ["/api/orders/:id" ::order]]))
 
-(r/match-by-path router "/api/ping")
-; #Match{:template "/api/ping"
-;        :data {:name ::ping}
-;        :result nil
-;        :path-params {}
-;        :path "/api/ping"}
+(into {} (r/match-by-path router "/api/ping"))
+;; => {:template "/api/ping"
+;;     :data {:name ::ping}
+;;     :result nil
+;;     :path-params {}
+;;     :path "/api/ping"}
 
-(r/match-by-name router ::order {:id 2})
-; #Match{:template "/api/orders/:id",
-;        :data {:name ::order},
-;        :result nil,
-;        :path-params {:id 2},
-;        :path "/api/orders/2"}
+(into {} (r/match-by-name router ::order {:id 2}))
+;; => {:template "/api/orders/:id",
+;;     :data {:name ::order},
+;;     :result nil,
+;;     :path-params {:id "2"},
+;;     :path "/api/orders/2"}
 ```
 
 ## Ring example
@@ -139,31 +140,32 @@ Valid request:
           :uri "/api/math"
           :query-params {:x "1", :y "2"}})
     (update :body slurp))
-; {:status 200
-;  :body "{\"total\":3}"
-;  :headers {"Content-Type" "application/json; charset=utf-8"}}
+;; => {:status 200
+;;     :body "{\"total\":3}"
+;;     :headers {"Content-Type" "application/json; charset=utf-8"}}
 ```
 
 Invalid request:
 
+<!-- FIXME: Not asserted because each run gets a new generated spec name -->
 ```clj
 (-> (app {:request-method :get
           :uri "/api/math"
           :query-params {:x "1", :y "a"}})
     (update :body jsonista.core/read-value))
-; {:status 400
-;  :headers {"Content-Type" "application/json; charset=utf-8"}
-;  :body {"spec" "(spec-tools.core/spec {:spec (clojure.spec.alpha/keys :req-un [:spec$8974/x :spec$8974/y]), :type :map, :leaf? false})"
-;         "value" {"x" "1"
-;                  "y" "a"}
-;         "problems" [{"via" ["spec$8974/y"]
-;                      "path" ["y"]
-;                      "pred" "clojure.core/int?"
-;                      "in" ["y"]
-;                      "val" "a"}]
-;         "type" "reitit.coercion/request-coercion"
-;         "coercion" "spec"
-;         "in" ["request" "query-params"]}}
+;; {:status 400
+;;  :headers {"Content-Type" "application/json; charset=utf-8"}
+;;  :body {"spec" "(spec-tools.core/spec {:spec (clojure.spec.alpha/keys :req-un [:spec$8974/x :spec$8974/y]), :type :map, :leaf? false})"
+;;         "value" {"x" "1"
+;;                  "y" "a"}
+;;         "problems" [{"via" ["spec$8974/y"]
+;;                      "path" ["y"]
+;;                      "pred" "clojure.core/int?"
+;;                      "in" ["y"]
+;;                      "val" "a"}]
+;;         "type" "reitit.coercion/request-coercion"
+;;         "coercion" "spec"
+;;         "in" ["request" "query-params"]}}
 ```
 
 ## More examples
@@ -209,6 +211,6 @@ Roadmap is mostly written in [issues](https://github.com/metosin/reitit/issues).
 
 ## License
 
-Copyright © 2017-2023 [Metosin Oy](http://www.metosin.fi)
+Copyright © 2017-2026 [Metosin Oy](http://www.metosin.fi)
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/doc/README.md
+++ b/doc/README.md
@@ -40,6 +40,7 @@ There is [#reitit](https://clojurians.slack.com/messages/reitit/) in [Clojurians
 
 All bundled:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit "0.10.1"]
 ```
@@ -63,52 +64,52 @@ Routing:
 
 ```clj
 (r/match-by-path router "/api/ipa")
-; nil
+;; => nil
 
 (r/match-by-path router "/api/ping")
-; #Match{:template "/api/ping"
-;        :data {:name ::ping}
-;        :result nil
-;        :path-params {}
-;        :path "/api/ping"}
+;; => {:template "/api/ping"
+;;     :data {:name ::ping}
+;;     :result nil
+;;     :path-params {}
+;;     :path "/api/ping"}
 
 (r/match-by-path router "/api/orders/1")
-; #Match{:template "/api/orders/:id"
-;        :data {:name ::order-by-id}
-;        :result nil
-;        :path-params {:id "1"}
-;        :path "/api/orders/1"}
+;; => {:template "/api/orders/:id"
+;;     :data {:name ::order-by-id}
+;;     :result nil
+;;     :path-params {:id "1"}
+;;     :path "/api/orders/1"}
 ```
 
 Reverse-routing:
 
 ```clj
 (r/match-by-name router ::ipa)
-; nil
+;; => nil
 
 (r/match-by-name router ::ping)
-; #Match{:template "/api/ping"
-;        :data {:name ::ping}
-;        :result nil
-;        :path-params {}
-;        :path "/api/ping"}
+;; => {:template "/api/ping"
+;;     :data {:name ::ping}
+;;     :result nil
+;;     :path-params {}
+;;     :path "/api/ping"}
 
 (r/match-by-name router ::order-by-id)
-; #PartialMatch{:template "/api/orders/:id"
-;               :data {:name :user/order-by-id}
-;               :result nil
-;               :path-params nil
-;               :required #{:id}}
+;; => {:template "/api/orders/:id"
+;;     :data {:name ::order-by-id}
+;;     :result nil
+;;     :path-params nil
+;;     :required #{:id}}
 
 (r/partial-match? (r/match-by-name router ::order-by-id))
-; true
+;; => true
 
 (r/match-by-name router ::order-by-id {:id 2})
-; #Match{:template "/api/orders/:id",
-;        :data {:name ::order-by-id},
-;        :result nil,
-;        :path-params {:id 2},
-;        :path "/api/orders/2"}
+;; => {:template "/api/orders/:id",
+;;     :data {:name ::order-by-id},
+;;     :result nil,
+;;     :path-params {:id "2"},
+;;     :path "/api/orders/2"}
 ```
 
 ## Ring router
@@ -140,10 +141,10 @@ Routing:
 
 ```clj
 (app {:request-method :get, :uri "/api/admin/users"})
-; {:status 200, :body "ok", :wrap (:api :admin)}
+;; => {:status 200, :body "ok", :wrap '(:api :admin)}
 
 (app {:request-method :put, :uri "/api/admin/users"})
-; nil
+;; => nil
 ```
 
 Reverse-routing:
@@ -152,11 +153,11 @@ Reverse-routing:
 (require '[reitit.core :as r])
 
 (-> app (ring/get-router) (r/match-by-name ::ping))
-; #Match{:template "/api/ping"
-;        :data {:middleware [[#object[user$wrap] :api]]
-;               :get {:handler #object[user$handler]}
-;        :name ::ping}
-;        :result #Methods{...}
-;        :path-params nil
-;        :path "/api/ping"}
+;; => {:template "/api/ping"
+;;     :data {:middleware ...
+;;            :get {:handler ...}
+;;     :name ::ping}
+;;     :result ...
+;;     :path-params nil
+;;     :path "/api/ping"}
 ```

--- a/doc/advanced/composing_routers.md
+++ b/doc/advanced/composing_routers.md
@@ -71,10 +71,12 @@ When a new router is created, all rules are applied, including the conflict reso
 (add-routes
   router2
   [["/:this/should/:fail" ::fail]])
-;CompilerException clojure.lang.ExceptionInfo: Router contains conflicting route paths:
-;
-;   /baz/:id/:subid
-;-> /:this/should/:fail
+;; =thrown-match=> {:type :path-conflicts}
+;;
+;; CompilerException clojure.lang.ExceptionInfo: Router contains conflicting route paths:
+;;
+;;    /baz/:id/:subid
+;; -> /:this/should/:fail
 ```
 
 ## Merging routers
@@ -127,12 +129,12 @@ Matching by path:
 
 ```clj
 (r/match-by-path router "/olipa/kerran/iso/kala")
-;#Match{:template "/olipa/*"
-;       :data {:name :olipa
-;              :router #object[reitit.core$mixed_router]}
-;       :result nil
-;       :path-params {: "kerran/iso/kala"}
-;       :path "/olipa/iso/kala"}
+;; => {:template "/olipa/*"
+;;     :data {:name :olipa
+;;            :router ...}
+;;     :result nil
+;;     :path-params {(keyword "") "kerran/iso/kala"}
+;;     :path "/olipa/kerran/iso/kala"}
 ```
 
 That didn't work as we wanted, as the nested routers don't have such a route. The core routing doesn't understand anything the `:router` key, so it only matched against the top-level router, which gave a match for the catch-all path.
@@ -155,30 +157,30 @@ With invalid nested path we get now `nil` as expected:
 
 ```clj
 (recursive-match-by-path router "/olipa/kerran/iso/kala")
-; nil
+;; => nil
 ```
 
 With valid path we get all the nested matches:
 
 ```clj
 (recursive-match-by-path router "/olipa/kerran/avaruus")
-;[#reitit.core.Match{:template "/olipa/*"
-;                    :data {:name :olipa
-;                           :router #object[reitit.core$mixed_router]}
-;                    :result nil
-;                    :path-params {: "kerran/avaruus"}
-;                    :path "/olipa/kerran/avaruus"}
-; #reitit.core.Match{:template "/kerran/*"
-;                    :data {:name :kerran
-;                           :router #object[reitit.core$lookup_router]}
-;                    :result nil
-;                    :path-params {: "avaruus"}
-;                    :path "/kerran/avaruus"}
-; #reitit.core.Match{:template "/avaruus" 
-;                    :data {:name :avaruus} 
-;                    :result nil 
-;                    :path-params {} 
-;                    :path "/avaruus"}]
+;;[{:template "/olipa/*"
+;;  :data {:name :olipa
+;;         :router ...}
+;;  :result nil
+;;  :path-params {: "kerran/avaruus"}
+;;  :path "/olipa/kerran/avaruus"}
+;; {:template "/kerran/*"
+;;  :data {:name :kerran
+;;         :router ...}
+;;  :result nil
+;;  :path-params {: "avaruus"}
+;;  :path "/kerran/avaruus"}
+;; {:template "/avaruus"
+;;  :data {:name :avaruus}
+;;  :result nil
+;;  :path-params {}
+;;  :path "/avaruus"}]
 ```
 
 Let's create a helper to get only the route names for matches:
@@ -189,7 +191,7 @@ Let's create a helper to get only the route names for matches:
            (mapv (comp :name :data))))
 
 (name-path router "/olipa/kerran/avaruus")
-; [:olipa :kerran :avaruus]
+;; => [:olipa :kerran :avaruus]
 ```
 
 So, we can nest routers, but why would we do that?
@@ -252,20 +254,20 @@ Matching root routes:
 
 ```clj
 (name-path router "/vodka/russian")
-; nil
+;; => nil
 
 (name-path router "/gin/napue")
-; [:napue]
+;; => [:napue]
 ```
 
 Matching (nested) beer routes:
 
 ```clj
 (name-path router "/beers/lager")
-; [:beers :lager]
+;; => [:beers :lager]
 
 (name-path router "/beers/saison")
-; nil
+;; => nil
 ```
 
 No saison!? Let's add the route:
@@ -285,20 +287,22 @@ We can't add conflicting routes:
 
 ```clj
 (swap! beer-router add-routes [["/saison" :saison]])
-;CompilerException clojure.lang.ExceptionInfo: Router contains conflicting route paths:
-;
-;   /saison
-;-> /saison
+;; =thrown-match=> {:type :path-conflicts}
+;;
+;; CompilerException clojure.lang.ExceptionInfo: Router contains conflicting route paths:
+;;
+;;    /saison
+;; -> /saison
 ```
 
 The dynamic routes are re-created on every request:
 
 ```clj
 (name-path router "/dynamic/duo")
-; [:dynamic :duo71]
+; => [:dynamic :duo71]
 
 (name-path router "/dynamic/duo")
-; [:dynamic :duo55]
+; => [:dynamic :duo55]
 ```
 
 ### Performance
@@ -319,13 +323,13 @@ The non-recursive lookup for `/gin/napue` is around 23ns.
 Comparing the dynamic routing performance with Compojure:
 
 ```clj
-(require '[compojure.core :refer [context])
+(require '[compojure.core :refer [context]])
 
 (def app
   (context "/dynamic" [] (constantly :duo)))
 
 (app {:uri "/dynamic/duo" :request-method :get})
-; :duo
+;; => :duo
 ```
 
 | path             | time    | type
@@ -347,8 +351,8 @@ A helper to the root router:
   (r/router
     [["/gin/napue" :napue]
      ["/ciders/*" :ciders]
-     ["/beers" (for [beer beers]
-                 [(str "/" beer) (keyword "beer" beer)])]
+     ["/beers" (vec (for [beer beers]
+                      [(str "/" beer) (keyword "beer" beer)]))]
      ["/dynamic/*" {:name :dynamic
                     :router dynamic-router}]]))
 ```
@@ -396,7 +400,7 @@ And the routing works:
 
 ```clj
 (name-path @router "/beers/sahti")
-;[:beer/sahti]
+;; => [:beer/sahti]
 ```
 
 All the beer-routes now match in constant time.
@@ -419,14 +423,16 @@ In order for a ring handler to be recomposed, we can wrap it into a handler that
 A simplified beer router version that creates a ring-handler.
 
 ```clj
+(require '[reitit.ring :as ring])
+
 (defn create-ring-handler [beers]
   (ring/ring-handler
    (ring/router
     [["/beers"
       (when (seq beers)
-        (for [beer beers]
-          [(str "/" beer)
-           {:get (fn [_] {:status 200 :body beer})}]))]])))
+        (vec (for [beer beers]
+               [(str "/" beer)
+                {:get (fn [_] {:status 200 :body beer})}])))]])))
 
 (def ring-handler
   (atom (create-ring-handler nil)))
@@ -439,7 +445,7 @@ We don't have any matching routes yet.
 
 ```clj
 ((deref-handler ring-handler) {:request-method :get :uri "/beers/lager"})
-; nil
+;; => nil
 ```
 
 But we can add them later.
@@ -447,7 +453,7 @@ But we can add them later.
 ```clj
 (reset-router! ["lager"])
 ((deref-handler ring-handler) {:request-method :get :uri "/beers/lager"})
-; {:status 200, :body "lager"}
+;; => {:status 200, :body "lager"}
 ```
 
 ## TODO

--- a/doc/advanced/dev_workflow.md
+++ b/doc/advanced/dev_workflow.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:skip true :apply :all-next} -->
 # Dev Workflow
 
 Many applications will require the routes to span multiple namespaces. It is quite easy to do so with reitit, but we might hit a problem during development.
@@ -35,12 +36,12 @@ Consider this sample routing :
 We may query the top router and get the expected result :
 ```clj
 (r/match-by-path router "/api/ns2/more/bar")
-;#reitit.core.Match{:template "/api/ns2/more/bar", :data {:name :ns1/bar}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
+;; => {:template "/api/ns2/more/bar", :data {:name :ns1/bar}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
 ```
 
-Notice the route name : ```:ns1/bar```
+Notice the route name : `:ns1/bar`
 
-When we change the routes in ```ns1``` like this :
+When we change the routes in `ns1` like this :
 ```clj
 (ns ns1
   (:require [reitit.core :as r]))
@@ -49,17 +50,17 @@ When we change the routes in ```ns1``` like this :
   ["/bar" ::bar-with-new-name])
 ```
 
-After we recompile the ```ns1``` namespace, and query again
+After we recompile the `ns1` namespace, and query again
 ```clj
 ns1/routes
 ;["/bar" :ns1/bar-with-new-name]
 ;The routes var in ns1 was changed indeed
 
 (r/match-by-path router "/api/ns2/more/bar")
-;#reitit.core.Match{:template "/api/ns2/more/bar", :data {:name :ns1/bar}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
+;; => {:template "/api/ns2/more/bar", :data {:name :ns1/bar}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
 ```
 
-The route name is still ```:ns1/bar``` !
+The route name is still `:ns1/bar` !
 
 While we could use the [reloaded workflow](http://thinkrelevance.com/blog/2013/06/04/clojure-workflow-reloaded) to reload the whole routing tree, it is not always possible, and quite frankly a bit slower than we might want for fast iterations.
 
@@ -97,12 +98,12 @@ Let's query again
 
 ```clj
 (r/match-by-path (router) "/api/ns2/more/bar") 
-;#reitit.core.Match{:template "/api/ns2/more/bar", :data {:name :ns1/bar}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
+;; => {:template "/api/ns2/more/bar", :data {:name :ns1/bar}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
 ```
 
-Notice that's we're now calling a function rather than just passing ```router``` to the matching function.
+Notice that's we're now calling a function rather than just passing `router` to the matching function.
 
-Now let's again change the route name in ```ns1```, and recompile that namespace.
+Now let's again change the route name in `ns1`, and recompile that namespace.
 
 ```clj
 (ns ns1)
@@ -115,7 +116,7 @@ let's see the query result :
 
 ```clj
 (r/match-by-path (router) "/api/ns2/more/bar")
-;#reitit.core.Match{:template "/api/ns2/more/bar", :data {:name :ns1/bar-with-new-name}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
+;; => {:template "/api/ns2/more/bar", :data {:name :ns1/bar-with-new-name}, :result nil, :path-params {}, :path "/api/ns2/more/bar"}
 ```
 
 Notice that the name is now correct, without reloading every namespace under the sun.
@@ -128,7 +129,7 @@ We need a way to only do this once at production time.
 
 ## An easy fix
 
-Let's apply a small change to our ```ns3```. We'll replace our router by two different routers, one for dev and one for production.
+Let's apply a small change to our `ns3`. We'll replace our router by two different routers, one for dev and one for production.
 
 ```clj
 (ns ns3)

--- a/doc/advanced/different_routers.md
+++ b/doc/advanced/different_routers.md
@@ -22,7 +22,7 @@ The router name can be asked from the router:
      ["/api/:users" ::users]]))
 
 (r/router-name router)
-; :mixed-router
+;; => :mixed-router
 ```
 
 Overriding the router implementation:
@@ -37,5 +37,5 @@ Overriding the router implementation:
     {:router r/linear-router}))
 
 (r/router-name router)
-; :linear-router
+;; => :linear-router
 ```

--- a/doc/advanced/route_validation.md
+++ b/doc/advanced/route_validation.md
@@ -28,6 +28,7 @@ Namespace `reitit.spec` contains [clojure.spec](https://clojure.org/about/spec) 
 
 First add a `:dev` dependency to:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [expound "0.4.0"] ; or higher
 ```

--- a/doc/advanced/shared_routes.md
+++ b/doc/advanced/shared_routes.md
@@ -42,11 +42,11 @@ Those can be used as-is from ClojureScript:
   (r/router routes))
 
 (r/match-by-name router ::kikka)
-;#Match{:template "/kikka"
-;       :data {:name :user/kikka}
-;       :result nil
-;       :path-params nil
-;       :path "/kikka"}
+;; => {:template "/kikka"
+;;     :data {:name ::kikka}
+;;     :result nil
+;;     :path-params nil
+;;     :path "/kikka"}
 ```
 
 For the backend, we can use a custom-expander to expand the routes:
@@ -81,5 +81,5 @@ For the backend, we can use a custom-expander to expand the routes:
                   ::bar bar})})))
 
 (app {:request-method :post, :uri "/kikka"})
-; {:status 200, :body "post"}
+;; => {:status 200, :body "post"}
 ```

--- a/doc/basics/error_messages.md
+++ b/doc/basics/error_messages.md
@@ -15,12 +15,14 @@ The default exception formatting uses `reitit.exception/exception`. It produces 
    ["/bulk/:bulk-id"]
    ["/public/*path"]
    ["/:version/status"]])
+;; =thrown-match=> {:type :path-conflicts}
 ```
 
 ![Pretty error](../images/conflicts1.png)
 
 ## Pretty Errors
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-dev "0.10.1"]
 ```
@@ -37,6 +39,7 @@ For human-readable and developer-friendly exception messages, there is `reitit.d
    ["/public/*path"]
    ["/:version/status"]]
   {:exception pretty/exception})
+;; =thrown-match=> {}
 ```
 
 ![Pretty error](../images/conflicts2.png)

--- a/doc/basics/name_based_routing.md
+++ b/doc/basics/name_based_routing.md
@@ -10,103 +10,103 @@ Given a router:
 (def router
   (r/router
     ["/api"
-     ["/ping" ::ping]
-     ["/user/:id" ::user]]))
+     ["/ping" :user/ping]
+     ["/user/:id" :user/user]]))
 ```
 
 Listing all route names:
 
 ```clj
 (r/route-names router)
-; [:user/ping :user/user]
+;; => [:user/ping :user/user]
 ```
 
 No match returns `nil`:
 
 ```clj
-(r/match-by-name router ::kikka)
-nil
+(r/match-by-name router :user/kikka)
+;; => nil
 ```
 
 Matching a route:
 
 ```clj
-(r/match-by-name router ::ping)
-; #Match{:template "/api/ping"
-;        :data {:name :user/ping}
-;        :result nil
-;        :path-params {}
-;        :path "/api/ping"}
+(r/match-by-name router :user/ping)
+;; => {:template "/api/ping"
+;;     :data {:name :user/ping}
+;;     :result nil
+;;     :path-params {}
+;;     :path "/api/ping"}
 ```
 
 If not all path-parameters are set, a `PartialMatch` is returned:
 
 ```clj
-(r/match-by-name router ::user)
-; #PartialMatch{:template "/api/user/:id",
-;               :data {:name :user/user},
-;               :result nil,
-;               :path-params nil,
-;               :required #{:id}}
+(r/match-by-name router :user/user)
+;; => {:template "/api/user/:id",
+;;     :data {:name :user/user},
+;;     :result nil,
+;;     :path-params nil,
+;;     :required #{:id}}
 
-(r/partial-match? (r/match-by-name router ::user))
-; true
+(r/partial-match? (r/match-by-name router :user/user))
+;; => true
 ```
 
 With provided path-parameters:
 
 ```clj
-(r/match-by-name router ::user {:id "1"})
-; #Match{:template "/api/user/:id"
-;        :data {:name :user/user}
-;        :path "/api/user/1"
-;        :result nil
-;        :path-params {:id "1"}}
+(r/match-by-name router :user/user {:id "1"})
+;; => {:template "/api/user/:id"
+;;     :data {:name :user/user}
+;;     :path "/api/user/1"
+;;     :result nil
+;;     :path-params {:id "1"}}
 ```
 
 Path-parameters are automatically coerced into strings, with the help of (currently internal) Protocol `reitit.impl/IntoString`. It supports strings, numbers, booleans, keywords and objects:
 
 ```clj
-(r/match-by-name router ::user {:id 1})
-; #Match{:template "/api/user/:id"
-;        :data {:name :user/user}
-;        :path "/api/user/1"
-;        :result nil
-;        :path-params {:id "1"}}
+(r/match-by-name router :user/user {:id 1})
+;; => {:template "/api/user/:id"
+;;     :data {:name :user/user}
+;;     :path "/api/user/1"
+;;     :result nil
+;;     :path-params {:id "1"}}
 ```
 
 In case you want to do something like generate a template path for documentation, you can disable url-encoding:
 
 ```clj
-(r/match-by-name router ::user {:id "<id goes here>"} {:url-encode? false})
-; #reitit.core.Match{:template "/api/user/:id"
-;                    :data {:name :user/user}
-;                    :path "/api/user/<id goes here>"
-;                    :result nil
-;                    :path-params {:id "<id goes here>"}}
+(r/match-by-name router :user/user {:id "<id goes here>"} {:url-encode? false})
+;; => {:template "/api/user/:id"
+;;     :data {:name :user/user}
+;;     :path "/api/user/<id goes here>"
+;;     :result nil
+;;     :path-params {:id "<id goes here>"}}
 ```
 
 There is also an exception throwing version:
 
 ```clj
-(r/match-by-name! router ::user)
-; ExceptionInfo missing path-params for route /api/user/:id: #{:id}
+(r/match-by-name! router :user/user)
+;; =thrown-match=> {:type "missing path-params for route /api/user/:id -> #{:id}"}
 ```
 
 To turn a Match into a path, there is `reitit.core/match->path`:
 
 ```clj
 (-> router
-    (r/match-by-name ::user {:id 1})
+    (r/match-by-name :user/user {:id 1})
     (r/match->path))
-; "/api/user/1"
+;; => "/api/user/1"
 ```
 
 It can take an optional map of query-parameters too:
 
 ```clj
 (-> router
-    (r/match-by-name ::user {:id 1})
+    (r/match-by-name :user/user {:id 1})
     (r/match->path {:iso "möly"}))
-; "/api/user/1?iso=m%C3%B6ly"
+;; => "/api/user/1?iso=m%C3%B6ly"
 ```

--- a/doc/basics/route_conflicts.md
+++ b/doc/basics/route_conflicts.md
@@ -1,6 +1,6 @@
 # Route Conflicts
 
-We should fail fast if a router contains conflicting paths or route names. 
+We should fail fast if a router contains conflicting paths or route names.
 
 When a `Router` is created via `reitit.core/router`, both path and route name conflicts are checked automatically. By default, in case of conflict, an `ex-info` is thrown with a descriptive message. In some (legacy api) cases, path conflicts should be allowed and one can override the path conflict resolution via `:conflicts` router option or via `:conflicting` route data.
 
@@ -23,6 +23,8 @@ Creating router with defaults:
 
 ```clj
 (r/router routes)
+;; =thrown-match=> {:type :path-conflicts}
+;
 ; CompilerException clojure.lang.ExceptionInfo: Router contains conflicting route paths:
 ;
 ; -> /:user-id/orders
@@ -55,19 +57,17 @@ To just log the conflicts:
   routes
   {:conflicts (fn [conflicts]
                 (println (exception/format-exception :path-conflicts nil conflicts)))})
-; Router contains conflicting route paths:
-;
-; -> /:user-id/orders
-; -> /public/*path
-; -> /bulk/:bulk-id
-;
-; -> /bulk/:bulk-id
-; -> /:version/status
-;
-; -> /public/*path
-; -> /:version/status
-;
-; => #object[reitit.core$quarantine_router$reify]
+;; Router contains conflicting route paths:
+;;
+;; -> /:user-id/orders
+;; -> /public/*path
+;; -> /bulk/:bulk-id
+;;
+;; -> /bulk/:bulk-id
+;; -> /:version/status
+;;
+;; -> /public/*path
+;; -> /:version/status
 ```
 
 Alternatively, you can ignore conflicting paths individually via `:conflicting` in route data:
@@ -81,7 +81,7 @@ Alternatively, you can ignore conflicting paths individually via `:conflicting` 
    ["/:version/status" {:conflicting true}]])
 ; => #'user/routes
 (r/router routes)
-;  => #object[reitit.core$quarantine_router$reify]
+; => #object[reitit.core$quarantine_router$reify]
 ```
 
 ## Name conflicts
@@ -99,6 +99,8 @@ Creating router with defaults:
 
 ```clj
 (r/router routes)
+;; =thrown-match=> {:type :name-conflicts}
+;
 ;CompilerException clojure.lang.ExceptionInfo: Router contains conflicting route names:
 ;
 ;:reitit.core/ping

--- a/doc/basics/route_data_validation.md
+++ b/doc/basics/route_data_validation.md
@@ -28,6 +28,8 @@ Failing fast with `clojure.spec` validation turned on:
 (r/router
   ["/api" {:handler "identity"}]
   {:validate rs/validate})
+;; =thrown-match=> {:type :reitit.spec/invalid-route-data}
+;
 ; CompilerException clojure.lang.ExceptionInfo: Invalid route data:
 ;
 ; -- On route -----------------------
@@ -51,6 +53,7 @@ Turning on [Pretty Errors](error_messages.md#pretty-errors) will give much nicer
   ["/api" {:handler "identity"}]
   {:validate rs/validate
    :exception pretty/exception})
+;; =thrown-match=> {:problems ... :reitit.exception/cause ...}
 ```
 
 ![Pretty error](../images/pretty-error.png)
@@ -79,6 +82,7 @@ Invalid spec value:
            ::roles #{:adminz}}]
   {:validate rs/validate
   :exception pretty/exception})
+;; =thrown-match=> {:problems ...}
 ```
 
 ![Invalid Role Error](../images/invalid_roles.png)
@@ -89,6 +93,7 @@ To fail-fast on non-defined and misspelled keys on route data, we can close the 
 
 Requiring a`:description` and validating using closed specs:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 (require '[spec-tools.spell :as spell])
 
@@ -107,6 +112,7 @@ Requiring a`:description` and validating using closed specs:
 
 It catches also typing errors:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 (r/router
   ["/api" {:descriptionz "kikka"}]

--- a/doc/basics/route_syntax.md
+++ b/doc/basics/route_syntax.md
@@ -14,6 +14,9 @@ Paths can have path-parameters (`:id`) or catch-all-parameters (`*path`). Parame
 Simple route:
 
 ```clj
+(defn ping [_req] nil)
+(defn pong [_req] nil)
+
 ["/ping" {:handler ping}]
 ```
 
@@ -29,11 +32,16 @@ Two routes with more data:
 Routes with path parameters (see also [Coercion](../coercion/coercion.md) and [Ring Coercion](../ring/coercion.md)):
 
 ```clj
+(defn get-user [_req] nil)
+(defn ping-version [_req] nil)
+
 [["/users/:user-id" {:handler get-user}]
  ["/api/:version/ping" {:handler ping-version}]]
 ```
 
 ```clj
+(defn get-pdf [_req] nil)
+
 [["/users/{user-id}" {:handler get-user}]
  ["/files/file-{number}.pdf" {:handler get-pdf}]
  ;; Two alternative syntaxes for qualified keyword params:
@@ -44,6 +52,8 @@ Routes with path parameters (see also [Coercion](../coercion/coercion.md) and [R
 Route with catch-all parameter:
 
 ```clj
+(defn get-file [_req] nil)
+
 ["/public/*path" {:handler get-file}]
 ```
 
@@ -77,6 +87,7 @@ Reitit does not apply any encoding to your paths. If you need that, you must enc
 
 Normal path-parameters (`:id`) can start anywhere in the path string, but have to end either to slash `/` (currently hardcoded) or to an end of path string:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [["/api/:version" {...}]
  ["/files/file-:number" {...}]
@@ -85,6 +96,7 @@ Normal path-parameters (`:id`) can start anywhere in the path string, but have t
 
 Bracket path-parameters can start and stop anywhere in the path-string, the following character is used as a terminator.
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [["/api/{version}" {...}]
  ["/files/{name}.{extension}" {...}]
@@ -93,6 +105,7 @@ Bracket path-parameters can start and stop anywhere in the path-string, the foll
 
 Having multiple terminators after a bracket path-path parameter with identical path prefix will cause a compile-time error at router creation:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [["/files/file-{name}.pdf" {...}]            ;; terminator \.
  ["/files/file-{name}-{version}.pdf" {...}]] ;; terminator \-
@@ -100,6 +113,7 @@ Having multiple terminators after a bracket path-path parameter with identical p
 
 ### Slash Free Routing
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [["broker.{customer}.{device}.{*data}" {...}]
  ["events.{target}.{type}" {...}]]

--- a/doc/basics/router.md
+++ b/doc/basics/router.md
@@ -22,15 +22,15 @@ Creating a router:
 (def router
   (r/router
     ["/api"
-     ["/ping" ::ping]
-     ["/user/:id" ::user]]))
+     ["/ping" :user/ping]
+     ["/user/:id" :user/user]]))
 ```
 
 Name of the created router:
 
 ```clj
 (r/router-name router)
-; :mixed-router
+;; => :mixed-router
 ```
 
 The flattened route tree:
@@ -49,18 +49,18 @@ Router options:
 
 ```clj
 (r/options router)
-{:lookup #object[...]
- :expand #object[...]
- :coerce #object[...]
- :compile #object[...]
- :conflicts #object[...]}
+=> {:lookup ...
+    :expand ...
+    :coerce ...
+    :compile ...
+    :conflicts ...}
 ```
 
 Route names:
 
 ```clj
 (r/route-names router)
-; [:user/ping :user/user]
+;; => [:user/ping :user/user]
 ```
 
 ### Composing
@@ -69,13 +69,13 @@ As routes are defined as plain data, it's easy to merge multiple route trees int
 
 ```clj
 (def user-routes
-  [["/users" ::users]
-   ["/users/:id" ::user]]) 
+  [["/users" :user/users]
+   ["/users/:id" :user/user]])
 
 (def admin-routes
   ["/admin"
-   ["/ping" ::ping]
-   ["/db" ::db]])
+   ["/ping" :user/ping]
+   ["/db" :user/db]])
 
 (def router
   (r/router

--- a/doc/coercion/clojure_spec_coercion.md
+++ b/doc/coercion/clojure_spec_coercion.md
@@ -55,8 +55,9 @@ Successful coercion:
 Failing coercion:
 
 ```clj
-(match-by-path-and-coerce! "/metosin/users/ikitommi")
-; => ExceptionInfo Request coercion failed...
+(try (match-by-path-and-coerce! "/metosin/users/ikitommi")
+     (catch Exception e (.getMessage e)))
+;; => "Request coercion failed"
 ```
 
 ## Deeply nested

--- a/doc/coercion/coercion.md
+++ b/doc/coercion/coercion.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:test-ns coercion-coercion-md :apply :all-next} -->
 # Coercion Explained
 
 Coercion is a process of transforming parameters (and responses) from one format into another. Reitit separates routing and coercion into two separate steps.
@@ -123,7 +124,7 @@ We can use a helper function `reitit.coercion/coerce!` to do the actual coercion
 ```clj
 (coercion/coerce!
   (r/match-by-path router "/metosin/users/123"))
-; {:path {:company "metosin", :user-id 123}}
+;; => {:path {:company "metosin", :user-id 123}}
 ```
 
 We get the coerced parameters back. If a coercion fails, a typed (`:reitit.coercion/request-coercion`) ExceptionInfo is thrown, with data about the actual error:
@@ -131,10 +132,9 @@ We get the coerced parameters back. If a coercion fails, a typed (`:reitit.coerc
 ```clj
 (coercion/coerce!
   (r/match-by-path router "/metosin/users/ikitommi"))
-; => ExceptionInfo Request coercion failed:
-; #CoercionError{:schema {:company java.lang.String, :user-id Int, Any Any},
-;                :errors {:user-id (not (integer? "ikitommi"))}}
-; clojure.core/ex-info (core.clj:4739)
+;; =thrown-match=> {:type :reitit.coercion/request-coercion
+;;                  :schema ...
+;;                  :errors {:user-id ...}}
 ```
 
 ## Full example
@@ -171,7 +171,7 @@ Here's a full example for doing routing and coercion with Reitit and Schema:
 ;        :path "/metosin/users/123"}
 
 (match-by-path-and-coerce! "/metosin/users/ikitommi")
-; => ExceptionInfo Request coercion failed...
+;; =thrown-match=> {:type :reitit.coercion/request-coercion}
 ```
 
 ## Ring Coercion

--- a/doc/coercion/data_spec_coercion.md
+++ b/doc/coercion/data_spec_coercion.md
@@ -9,7 +9,7 @@
 
 (def router
   (r/router
-    ["/:company/users/:user-id" {:name ::user-view
+    ["/:company/users/:user-id" {:name :user/user-view
                                  :coercion reitit.coercion.spec/coercion
                                  :parameters {:path {:company string?
                                                      :user-id int?}}}]
@@ -24,20 +24,17 @@ Successful coercion:
 
 ```clj
 (match-by-path-and-coerce! "/metosin/users/123")
-; #Match{:template "/:company/users/:user-id",
-;        :data {:name :user/user-view,
-;               :coercion <<:spec>>
-;               :parameters {:path {:company string?,
-;                                   :user-id int?}}},
-;        :result {:path #object[reitit.coercion$request_coercer$]},
-;        :path-params {:company "metosin", :user-id "123"},
-;        :parameters {:path {:company "metosin", :user-id 123}}
-;        :path "/metosin/users/123"}
+;; => {:template "/:company/users/:user-id",
+;;     :data {:name :user/user-view,
+;;            :coercion ...
+;;            :parameters ...}
+;;     :path-params {:company "metosin", :user-id "123"},
+;;     :parameters {:path {:company "metosin", :user-id 123}}}
 ```
 
 Failing coercion:
 
 ```clj
 (match-by-path-and-coerce! "/metosin/users/ikitommi")
-; => ExceptionInfo Request coercion failed...
+;; =thrown-match=> {:type :reitit.coercion/request-coercion, :problems ...}
 ```

--- a/doc/coercion/malli_coercion.md
+++ b/doc/coercion/malli_coercion.md
@@ -28,9 +28,12 @@ By default, [Vector Syntax](https://github.com/metosin/malli#vector-syntax) is u
 Successful coercion:
 
 ```clj
-(-> (into {} (match-by-path-and-coerce! "/metosin/users/123"))
-    (dissoc :result :data))
+(match-by-path-and-coerce! "/metosin/users/123")
 ;; => {:template "/:company/users/:user-id",
+;;     :data {:name :user/user-view
+;;            :coercion ...
+;;            :parameters ...}
+;;     :result ...
 ;;     :path-params {:company "metosin", :user-id "123"},
 ;;     :parameters {:path {:company "metosin", :user-id 123}}
 ;;     :path "/metosin/users/123"}

--- a/doc/coercion/schema_coercion.md
+++ b/doc/coercion/schema_coercion.md
@@ -10,7 +10,7 @@
 
 (def router
   (r/router
-    ["/:company/users/:user-id" {:name ::user-view
+    ["/:company/users/:user-id" {:name :user/user-view
                                  :coercion reitit.coercion.schema/coercion
                                  :parameters {:path {:company s/Str
                                                      :user-id s/Int}}}]
@@ -25,20 +25,19 @@ Successful coercion:
 
 ```clj
 (match-by-path-and-coerce! "/metosin/users/123")
-; #Match{:template "/:company/users/:user-id",
-;        :data {:name :user/user-view,
-;               :coercion <<:schema>>
-;               :parameters {:path {:company java.lang.String,
-;                                   :user-id Int}}},
-;        :result {:path #object[reitit.coercion$request_coercer$]},
-;        :path-params {:company "metosin", :user-id "123"},
-;        :parameters {:path {:company "metosin", :user-id 123}}
-;        :path "/metosin/users/123"}
+;; => {:template "/:company/users/:user-id",
+;;     :data {:name :user/user-view,
+;;            :coercion ...
+;;            :parameters ...}
+;;     :result ...,
+;;     :path-params {:company "metosin", :user-id "123"},
+;;     :parameters {:path {:company "metosin", :user-id 123}}
+;;     :path "/metosin/users/123"}
 ```
 
 Failing coercion:
 
 ```clj
 (match-by-path-and-coerce! "/metosin/users/ikitommi")
-; => ExceptionInfo Request coercion failed...
+;; =thrown-match=> {:type :reitit.coercion/request-coercion}
 ```

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -130,7 +130,7 @@ Compojure:
                   :handler (fn [{:keys [parameters]}]
                              (ok (get-user (-> parameters :body :id))))}
     ["/pizza" {:post {:middleware [wrap-log]
-                      :handler post-pizza-handler}]]])
+                      :handler post-pizza-handler}}]]])
 ```
 
 #### Features

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -111,6 +111,15 @@ Reitit routing was originally based on Pedestal Routing an thus they same simila
 Compojure:
 
 ```clj
+(require '[compojure.core :refer [defroutes wrap-routes context GET POST]])
+(require '[compojure.coercions :refer [as-int]])
+(require '[ring.util.http-response :refer [ok]])
+
+(defn wrap-api [handler x] :example)
+(defn wrap-log [handler] :example)
+(defn get-user [id] :example)
+(defn post-pizza-handler [_req] :example)
+
 (defroutes routes
   (wrap-routes
     (context "/api" []
@@ -124,6 +133,7 @@ Compojure:
 `reitit-ring` with `reitit-spec` module:
 
 ```clj
+
 (def routes
   ["/api" {:middleware [[wrap-api :secure]]}
    ["/users/:id" {:get {:parameters {:path {:id int?}}}

--- a/doc/frontend/basics.md
+++ b/doc/frontend/basics.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:platform :cljs :apply :all-next} -->
 # Frontend basics
 
 Reitit frontend integration is built from multiple layers:

--- a/doc/frontend/browser.md
+++ b/doc/frontend/browser.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:platform :cljs} -->
 # Frontend browser integration
 
 Reitit includes two browser history integrations.
@@ -38,7 +39,7 @@ anchor clicks where the href matches route tree normally (i.e. browser load)
 you can provide `:ignore-anchor-click?` function to add your own logic to
 event handling:
 
-```clj
+```cljs
 (rfe/start!
   router
   on-navigate-fn

--- a/doc/frontend/coercion.md
+++ b/doc/frontend/coercion.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:platform :cljs :test-ns frontend-coercion-md :apply :all-next} -->
 # Frontend coercion
 
 The Reitit frontend leverages [coercion](../coercion/coercion.md) for path,

--- a/doc/frontend/controllers.md
+++ b/doc/frontend/controllers.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:platform :cljs :apply :all-next} -->
 # Controllers
 
 * https://github.com/metosin/reitit/tree/master/examples/frontend-controllers

--- a/doc/http/default_interceptors.md
+++ b/doc/http/default_interceptors.md
@@ -1,5 +1,6 @@
 # Default Interceptors
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-interceptors "0.10.1"]
 ```

--- a/doc/http/interceptors.md
+++ b/doc/http/interceptors.md
@@ -4,6 +4,7 @@ Reitit has also support for [interceptors](http://pedestal.io/reference/intercep
 
 ## Reitit-http
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-http "0.10.1"]
 ```

--- a/doc/http/pedestal.md
+++ b/doc/http/pedestal.md
@@ -1,7 +1,9 @@
+<!-- #:test-doc-blocks{:skip true :apply :all-next} -->
 # Pedestal
 
 [Pedestal](http://pedestal.io/) is a backend web framework for Clojure. `reitit-pedestal` provides an alternative routing engine for Pedestal.
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-pedestal "0.10.1"]
 ```

--- a/doc/http/sieppari.md
+++ b/doc/http/sieppari.md
@@ -1,5 +1,6 @@
 # Sieppari
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-sieppari "0.10.1"]
 ```

--- a/doc/http/transforming_interceptor_chain.md
+++ b/doc/http/transforming_interceptor_chain.md
@@ -9,6 +9,7 @@ There is an extra option in http-router (actually, in the underlying interceptor
 ```clj
 (require '[reitit.http :as http])
 (require '[reitit.interceptor.sieppari :as sieppari])
+(require '[reitit.interceptor :as interceptor])
 
 (defn interceptor [message]
   {:enter (fn [ctx] (update-in ctx [:request :message] (fnil conj []) message))})
@@ -64,12 +65,14 @@ There is an extra option in http-router (actually, in the underlying interceptor
 
 ### Printing Context Diffs
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-interceptors "0.10.1"]
 ```
 
 Using `reitit.http.interceptors.dev/print-context-diffs` transformation, the context diffs between each interceptor are printed out to the console. To use it, add the following router option:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 :reitit.interceptor/transform reitit.http.interceptor.dev/print-context-diffs
 ```

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:skip true :apply :all-next} -->
 # Performance
 
 Reitit tries to be really, really fast.

--- a/doc/ring/RESTful_form_methods.md
+++ b/doc/ring/RESTful_form_methods.md
@@ -26,7 +26,7 @@ We can do this with middleware in reitit like this:
 And apply the middleware like this:
 ```clj
 (reitit.ring/ring-handler
-  (reitit.ring/router ...)
+  (reitit.ring/router [])
   (reitit.ring/create-default-handler)
   {:middleware
     [reitit.ring.middleware.parameters/parameters-middleware ;; needed to have :form-params in the request map

--- a/doc/ring/coercion.md
+++ b/doc/ring/coercion.md
@@ -1,3 +1,4 @@
+<!-- #:test-doc-blocks{:test-ns ring-coercion-md :apply :all-next} -->
 # Ring Coercion
 
 Basic coercion is explained in detail [in the Coercion Guide](../coercion/coercion.md). With Ring, both request parameters and response bodies can be coerced.
@@ -70,6 +71,7 @@ other [route data](../basics/route_data.md). There is special case
 handling for merging eg. malli `:map` schemas.
 
 ```clj
+(require 'reitit.coercion.malli)
 (def router
  (reitit.ring/router
    ["/api" {:get {:parameters {:query [:map [:api-key :string]]}}}

--- a/doc/ring/compiling_middleware.md
+++ b/doc/ring/compiling_middleware.md
@@ -13,6 +13,9 @@ To demonstrate the two approaches, below is the response coercion middleware wri
 * Reads the compiled route information on every request. Everything is done at request-time.
 
 ```clj
+(require '[reitit.ring :as ring])
+(require '[reitit.coercion :as coercion :refer [response-coercer]])
+
 (defn wrap-coerce-response
   "Middleware for pluggable response coercion.
   Expects a :coercion of type `reitit.coercion/Coercion`
@@ -77,6 +80,7 @@ Often it is useful to require a route to provide a specific key.
 
 ```clj
 (require '[buddy.auth.accessrules :as accessrules])
+(require '[clojure.spec.alpha :as s])
 
 (s/def ::authorize
   (s/or :handler :accessrules/handler :rule :accessrules/rule))

--- a/doc/ring/content_negotiation.md
+++ b/doc/ring/content_negotiation.md
@@ -53,7 +53,8 @@ Expected route data:
                            rrc/coerce-request-middleware
                            rrc/coerce-response-middleware]}})))
 
-(jetty/run-jetty #'app {:port 3000, :join? false})
+(defn start []
+  (jetty/run-jetty #'app {:port 3000, :join? false}))
 ```
 
 Testing with [httpie](https://httpie.org/):
@@ -120,10 +121,10 @@ The example below is from `muuntaja` explaining how to add a custom encoder to p
       [:formats "application/json" :encoder-opts]
       {:date-format "yyyy-MM-dd"})))
 
-(->> {:value (java.util.Date.)}
-     (m/encode m "application/json")
+(->> {:value (java.util.Date. 119 9 15 12 0)}
+     (m/encode muuntaja-instance "application/json")
      slurp)
-; => "{\"value\":\"2019-10-15\"}"
+;; => "{\"value\":\"2019-10-15\"}"
 
 ```
 

--- a/doc/ring/default_middleware.md
+++ b/doc/ring/default_middleware.md
@@ -1,5 +1,6 @@
 # Default Middleware
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-middleware "0.10.1"]
 ```
@@ -47,6 +48,7 @@ Expected route data:
 
 `reitit.ring.middleware.dev/print-request-diffs` is a [middleware chain transforming function](transforming_middleware_chain.md). It prints a request and response diff between each middleware. To use it, add the following router option:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 :reitit.middleware/transform reitit.ring.middleware.dev/print-request-diffs
 ```

--- a/doc/ring/exceptions.md
+++ b/doc/ring/exceptions.md
@@ -1,5 +1,6 @@
 # Exception Handling with Ring
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-middleware "0.10.1"]
 ```

--- a/doc/ring/middleware_registry.md
+++ b/doc/ring/middleware_registry.md
@@ -43,13 +43,15 @@ Router creation fails fast if the registry doesn't contain the middleware:
                   :get (fn [{:keys [bonus]}]
                          {:status 200, :body {:bonus bonus}})}]]
       {::middleware/registry {:bonus wrap-bonus}})))
-;CompilerException clojure.lang.ExceptionInfo: Middleware :bonus10 not found in registry.
-;
-;Available middleware in registry:
-;
-;|    :id |                         :description |
-;|--------+--------------------------------------|
-;| :bonus | reitit.ring_test$wrap_bonus@59fddabb |
+;; =thrown-match=> {:id :bonus10}
+;;
+;; CompilerException clojure.lang.ExceptionInfo: Middleware :bonus10 not found in registry.
+;;
+;; Available middleware in registry:
+;;
+;; |    :id |                         :description |
+;; |--------+--------------------------------------|
+;; | :bonus | reitit.ring_test$wrap_bonus@59fddabb |
 ```
 
 Middleware defined in the registry can also be used on the `ring-handler` level:

--- a/doc/ring/openapi.md
+++ b/doc/ring/openapi.md
@@ -111,7 +111,7 @@ A straightforward use case is adding `"externalDocs"`:
  {:get {:summary "Fetch an account | Recursive schemas using malli registry, link to external docs"
         :openapi {:externalDocs {:description "The reitit repository"
                                  :url "https://github.com/metosin/reitit"}}
-        ...}}]
+        ... ...}}]
 ```
 
 In a more complex use case is providing `"securitySchemes"`. See
@@ -148,6 +148,8 @@ Malli:
 Schema:
 
 ```clj
+(require '[schema.core :as s])
+
 ["/plus"
  {:post
   {:parameters
@@ -165,11 +167,11 @@ Spec:
  {:post
   {:parameters
    {:body (spec-tools.data-spec/spec ::foo
-                                     {:x (schema-tools.core/spec {:spec int?
-                                                                  :description "Description for X parameter"
-                                                                  :openapi/deprecated true
-                                                                  :openapi/example 13
-                                                                  :openapi/default 42})
+                                     {:x (spec-tools.core/spec {:spec int?
+                                                                :description "Description for X parameter"
+                                                                :openapi/deprecated true
+                                                                :openapi/example 13
+                                                                :openapi/default 42})
                                       :y int?})}}}]
 ```
 

--- a/doc/ring/openapi.md
+++ b/doc/ring/openapi.md
@@ -60,7 +60,7 @@ openapi example](../../examples/openapi).
                                                                [:color :keyword]
                                                                [:pineapple :boolean]]
                                                       :examples {:red {:description "Red pizza with pineapple"
-                                                                       :value (pr-str {:color :red :pineapple true})}}}}}}
+                                                                       :value (pr-str {:color :red :pineapple true})}}}}}}}}]
 ```
 
 The special `:default` content types map to the content types supported by the Muuntaja
@@ -170,7 +170,7 @@ Spec:
                                                                   :openapi/deprecated true
                                                                   :openapi/example 13
                                                                   :openapi/default 42})
-                                      :y int?}}}}}]
+                                      :y int?})}}}]
 ```
 
 ### Adding examples

--- a/doc/ring/ring.md
+++ b/doc/ring/ring.md
@@ -4,6 +4,7 @@
 
 Read more about the [Ring Concepts](https://github.com/ring-clojure/ring/wiki/Concepts).
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-ring "0.10.1"]
 ```
@@ -39,12 +40,11 @@ Match contains `:result` compiled by `reitit.ring/router`:
 (require '[reitit.core :as r])
 
 (r/match-by-path router "/ping")
-;#Match{:template "/ping"
-;       :data {:get {:handler #object[...]}}
-;       :result #Methods{:get #Endpoint{...}
-;                        :options #Endpoint{...}}
-;       :path-params {}
-;       :path "/ping"}
+;; => {:template "/ping"
+;;     :data {:get {:handler ...}}
+;;     :result ...
+;;     :path-params {}
+;;     :path "/ping"}
 ```
 
 ## `reitit.ring/ring-handler`
@@ -67,12 +67,12 @@ Applying the handler:
 
 ```clj
 (app {:request-method :get, :uri "/favicon.ico"})
-; nil
+;; => nil
 ```
 
 ```clj
 (app {:request-method :get, :uri "/ping"})
-; {:status 200, :body "ok"}
+;; => {:status 200, :body "ok"}
 ```
 
 The router can be accessed via `get-router`:
@@ -109,24 +109,24 @@ Top-level handler catches all methods:
 
 ```clj
 (app {:request-method :delete, :uri "/all"})
-; {:status 200, :body "ok"}
+;; => {:status 200, :body "ok"}
 ```
 
 Method-level handler catches only the method:
 
 ```clj
 (app {:request-method :get, :uri "/ping"})
-; {:status 200, :body "ok"}
+;; => {:status 200, :body "ok"}
 
 (app {:request-method :put, :uri "/ping"})
-; nil
+;; => nil
 ```
 
 By default, `:options` is also supported (see router options to change this):
 
 ```clj
 (app {:request-method :options, :uri "/ping"})
-; {:status 200, :body ""}
+;; => {:status 200, :body ""}
 ```
 
 Name-based reverse routing:
@@ -136,7 +136,7 @@ Name-based reverse routing:
     (ring/get-router)
     (r/match-by-name ::ping)
     (r/match->path))
-; "/ping"
+;; => "/ping"
 ```
 
 # Middleware
@@ -180,12 +180,12 @@ Middleware is applied correctly:
 
 ```clj
 (app {:request-method :delete, :uri "/api/ping"})
-; {:status 200, :body [:api :handler]}
+;; => {:status 200, :body [:api :handler]}
 ```
 
 ```clj
 (app {:request-method :delete, :uri "/api/admin/db"})
-; {:status 200, :body [:api :admin :db :delete :handler]}
+;; => {:status 200, :body [:api :admin :db :delete :handler]}
 ```
 
 Top-level middleware, applied before any routing is done:
@@ -200,7 +200,7 @@ Top-level middleware, applied before any routing is done:
     {:middleware [[wrap :top]]}))
 
 (app {:request-method :get, :uri "/api/get"})
-; {:status 200, :body [:top :api :ok]}
+;; => {:status 200, :body [:top :api :handler]}
 ```
 
 Same middleware for all routes, using [top-level route data](route_data.md#top-level-route-data):
@@ -215,7 +215,7 @@ Same middleware for all routes, using [top-level route data](route_data.md#top-l
       {:data {:middleware [[wrap :generic]]}})))
 
 (app {:request-method :get, :uri "/api/get"})
-; {:status 200, :body [:generic :specific :handler]}
+;; => {:status 200, :body [:generic :specific :handler]}
 ```
 
 ## Execution order
@@ -236,7 +236,7 @@ using all of the above techniques:
     {:middleware [[wrap :1-top]]}))
 
 (app {:request-method :get, :uri "/api/get"})
-; {:status 200, :body [:1-top :2-top-level-route-data :3-parent :4-route :handler]}
+;; => {:status 200, :body [:1-top :2-top-level-route-data :3-parent :4-route :handler]}
 ```
 
 ## Which method should I use for defining middleware?

--- a/doc/ring/route_data_validation.md
+++ b/doc/ring/route_data_validation.md
@@ -196,7 +196,7 @@ But fails if they are present and invalid:
         ["/ping" {:get handler}]]
        ["/internal" {:zone :internal}
         ["/users" {:get {:handler handler
-                         ::roles #{:manager} ;; <--- added
+                         ::roles #{:manager}} ;; <--- added
                    :delete {:handler handler
                             ::roles #{:adminz}}}]]] ;; <--- added
       {:validate rrs/validate

--- a/doc/ring/route_data_validation.md
+++ b/doc/ring/route_data_validation.md
@@ -37,7 +37,7 @@ All good:
 ```clj
 (app {:request-method :get
       :uri "/api/internal/users"})
-; {:status 200, :body "ok"}
+;; => {:status 200, :body "ok"}
 ```
 
 ### Explicit specs via middleware
@@ -53,7 +53,7 @@ Middleware that requires `:zone` to be present in route data:
    :wrap (fn [handler]
            (fn [request]
              (let [zone (-> request (ring/get-match) :data :zone)]
-               (println zone)
+               (println "in zone" zone)
                (handler request))))})
 ```
 
@@ -71,6 +71,8 @@ Missing route data fails fast at router creation:
                    :delete {:handler handler}}]]]
       {:validate rrs/validate
        ::rs/explain e/expound-str})))
+;; =thrown-match=> {:type :reitit.spec/invalid-route-data}
+;
 ; CompilerException clojure.lang.ExceptionInfo: Invalid route data:
 ;
 ; -- On route -----------------------
@@ -138,8 +140,9 @@ Adding the `:zone` to route data fixes the problem:
 
 (app {:request-method :get
       :uri "/api/internal/users"})
-; in zone :internal
-; => {:status 200, :body "ok"}
+;; => {:status 200, :body "ok"}
+;; =stdout=>
+;; in zone :internal
 ```
 
 ### Implicit specs
@@ -179,9 +182,10 @@ Let's reuse the `wrap-enforce-roles` from [Dynamic extensions](dynamic_extension
        ::rs/explain e/expound-str})))
 
 (app {:request-method :get
-      :uri "/api/zones/admin/ping"})
-; in zone :internal
-; => {:status 200, :body "ok"}
+      :uri "/api/internal/users"})
+;; => {:status 200, :body "ok"}
+;; =stdout=>
+;; in zone :internal
 ```
 
 But fails if they are present and invalid:
@@ -201,6 +205,8 @@ But fails if they are present and invalid:
                             ::roles #{:adminz}}}]]] ;; <--- added
       {:validate rrs/validate
        ::rs/explain e/expound-str})))
+;; =thrown-match=> {:type :reitit.spec/invalid-route-data}
+;
 ; CompilerException clojure.lang.ExceptionInfo: Invalid route data:
 ;
 ; -- On route -----------------------

--- a/doc/ring/swagger.md
+++ b/doc/ring/swagger.md
@@ -1,6 +1,7 @@
 # Swagger Support
 
-```
+<!-- #:test-doc-blocks{:skip true} -->
+```clj
 [metosin/reitit-swagger "0.10.1"]
 ```
 
@@ -46,7 +47,8 @@ If you need to post-process the generated spec, just wrap the handler with a cus
 
 [Swagger-ui](https://github.com/swagger-api/swagger-ui) is a user interface to visualize and interact with the Swagger specification. To make things easy, there is a pre-integrated version of the swagger-ui as a separate module.
 
-```
+<!-- #:test-doc-blocks{:skip true} -->
+```clj
 [metosin/reitit-swagger-ui "0.10.1"]
 ```
 
@@ -147,6 +149,7 @@ Another way to serve the swagger-ui is using the [default handler](default_handl
 
 Whole example project is in [`/examples/ring-spec-swagger`](https://github.com/metosin/reitit/tree/master/examples/ring-spec-swagger).
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 (ns example.server
   (:require [reitit.ring :as ring]

--- a/doc/ring/transforming_middleware_chain.md
+++ b/doc/ring/transforming_middleware_chain.md
@@ -58,12 +58,14 @@ There is an extra option in the Ring router (actually, in the underlying middlew
 
 ### Printing Request Diffs
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 [metosin/reitit-middleware "0.10.1"]
 ```
 
 Using `reitit.ring.middleware.dev/print-request-diffs` transformation, the request diffs between each middleware are printed out to the console. To use it, add the following router option:
 
+<!-- #:test-doc-blocks{:skip true} -->
 ```clj
 :reitit.middleware/transform reitit.ring.middleware.dev/print-request-diffs
 ```

--- a/project.clj
+++ b/project.clj
@@ -156,7 +156,10 @@
                                             "-Dclojure.compiler.direct-linking=true"
                                             "-XX:+PrintCompilation"
                                             "-XX:+UnlockDiagnosticVMOptions"
-                                            "-XX:+PrintInlining"]}}
+                                            "-XX:+PrintInlining"]}
+
+             :gen-doc-tests {:test-paths   ^:replace ["target/test-doc-blocks/test"]
+                             :dependencies [[com.github.lread/test-doc-blocks "1.2.21"]]}}
   :aliases {"all" ["with-profile" "dev,default"]
             "perf" ["with-profile" "default,dev,perf"]
             "test-clj" ["all" "do" ["bat-test"] ["check"]]
@@ -165,7 +168,12 @@
             ;; the same way.
             "test-browser" ["doo" "chrome-headless" "test"]
             "test-advanced" ["doo" "chrome-headless" "advanced-test"]
-            "test-node" ["doo" "node" "node-test"]}
+            "test-node" ["doo" "node" "node-test"]
+
+            "test-docs" ["with-profile" "dev,gen-doc-tests" "do"
+                         ["run" "-m" "lread.test-doc-blocks" "gen-tests" "--platform" "clj"
+                          "README.md" "doc/coercion/malli_coercion.md"]
+                         ["test"]]}
 
   :bat-test {:report [:pretty
                       {:type :junit

--- a/project.clj
+++ b/project.clj
@@ -159,7 +159,7 @@
                                             "-XX:+PrintInlining"]}
 
              :gen-doc-tests {:test-paths   ^:replace ["target/test-doc-blocks/test"]
-                             :dependencies [[com.github.lread/test-doc-blocks "1.2.21-1"]
+                             :dependencies [[com.github.metosin/test-doc-blocks "1.2.21-reitit1"]
                                             [compojure "1.7.2"]
                                             [buddy "2.0.0"]]}}
   :aliases {"all" ["with-profile" "dev,default"]

--- a/project.clj
+++ b/project.clj
@@ -159,7 +159,9 @@
                                             "-XX:+PrintInlining"]}
 
              :gen-doc-tests {:test-paths   ^:replace ["target/test-doc-blocks/test"]
-                             :dependencies [[com.github.lread/test-doc-blocks "1.2.21"]]}}
+                             :dependencies [[com.github.lread/test-doc-blocks "1.2.21-1"]
+                                            [compojure "1.7.2"]
+                                            [buddy "2.0.0"]]}}
   :aliases {"all" ["with-profile" "dev,default"]
             "perf" ["with-profile" "default,dev,perf"]
             "test-clj" ["all" "do" ["bat-test"] ["check"]]
@@ -171,8 +173,8 @@
             "test-node" ["doo" "node" "node-test"]
 
             "test-docs" ["with-profile" "dev,gen-doc-tests" "do"
-                         ["run" "-m" "lread.test-doc-blocks" "gen-tests" "--platform" "clj"
-                          "README.md" "doc/coercion/malli_coercion.md"]
+                         ["run" "-m" "lread.test-doc-blocks" "gen-tests"
+                          "README.md" "doc/**.md"]
                          ["test"]]}
 
   :bat-test {:report [:pretty


### PR DESCRIPTION
I suspected the malli coercion custom registry example was broken, so I wanted to get it tested and the coercion Malli options indeed had an extra layer of map.

TODO:
- [ ] Run on CI
- [ ] Enable for more doc files
- [x] I would like to use matcher-combinators or something to write the assertions, as there are many cases where return values include some records or reify values, or Clojure.spec instances which are different on each run.