### PR TITLE
Allow data: images in pedestal-swagger CSP

### DIFF
--- a/examples/pedestal-swagger/src/example/server.clj
+++ b/examples/pedestal-swagger/src/example/server.clj
@@ -122,9 +122,10 @@
        ::server/join? false
        ;; no pedestal routes
        ::server/routes []
-       ;; allow serving the swagger-ui styles & scripts from self
+       ;; allow serving the swagger-ui styles, scripts and inline images from self
        ::server/secure-headers {:content-security-policy-settings
                                 {:default-src "'self'"
+                                 :img-src "'self' data:"
                                  :style-src "'self' 'unsafe-inline'"
                                  :script-src "'self' 'unsafe-inline'"}}}
       (server/default-interceptors)


### PR DESCRIPTION
Closes #447. Adds `:img-src "'self' data:"` to the pedestal-swagger example's secure-headers so Swagger UI's inline SVG checkbox icons render correctly. Mirrors the snippet @opqdonut said "PR welcome!" for in the issue thread.