### PR TITLE
Extend Expand to APersistentMap on JVM

### DIFF
--- a/modules/reitit-core/src/reitit/core.cljc
+++ b/modules/reitit-core/src/reitit/core.cljc
@@ -16,12 +16,11 @@
      :cljs cljs.core.Keyword)
   (expand [this _] {:name this})
 
-  #?(:clj  clojure.lang.PersistentArrayMap
+  #?(:clj  clojure.lang.APersistentMap
      :cljs cljs.core.PersistentArrayMap)
   (expand [this _] this)
 
-  #?(:clj  clojure.lang.PersistentHashMap
-     :cljs cljs.core.PersistentHashMap)
+  #?(:cljs cljs.core.PersistentHashMap)
   (expand [this _] this)
 
   #?(:clj  clojure.lang.Fn


### PR DESCRIPTION
## Summary
- On JVM, extend `reitit.core/Expand` to `clojure.lang.APersistentMap` instead of the concrete `PersistentArrayMap` / `PersistentHashMap` classes.

Behavior for stock Clojure maps is unchanged (`expand` still returns `this`). Protocol dispatch continues to cache per concrete class after first resolve.

This keeps route-data map expansion working for any `APersistentMap` subclass (e.g. `PersistentTreeMap`, and alternate JVM Clojure runtimes that provide their own map implementations under that hierarchy), without requiring library-specific reader features.

## Reason
[Cloffle](https://github.com/The-Alchemist/cloffle-clojure) is a GraalVM/Truffle Clojure runtime with specialized map types that extend `APersistentMap` but not `PersistentArrayMap` / `PersistentHashMap`. Extending those concrete classes means Cloffle map literals miss `Expand`; targeting `APersistentMap` fixes that without changing stock Clojure behavior.

We  use `reitit`  as part of our compatibility tests with Clojure, and we maintain this patch for `reitit` internally.  This PR would help us avoid that, without any performance impact on reitit itself.