### PR TITLE
Detect variadic arities of :error interceptors

### DIFF
--- a/modules/reitit-pedestal/src/reitit/pedestal.clj
+++ b/modules/reitit-pedestal/src/reitit/pedestal.clj
@@ -5,18 +5,62 @@
             [reitit.exception :as ex]
             [reitit.http]
             [reitit.interceptor])
-  (:import (java.lang.reflect Method)))
+  (:import (clojure.lang RestFn)
+           (java.lang.reflect Method)))
 
-;; TODO: variadic
-(defn- arities [f]
+(defn- required-arity
+  "Number of positional parameters in an `:arglists` signature, ignoring any
+   variadic tail: `[context ex]` -> 2, `[context & args]` -> 1."
+  [arglist]
+  (count (take-while #(not= '& %) arglist)))
+
+(defn- variadic-arglist? [arglist]
+  (boolean (some #(= '& %) arglist)))
+
+(defn- declared-invoke-arities
+  "Arities of the `invoke` methods declared on `f`'s class. Fns compiled by
+   Clojure on the JVM only declare the arities they actually define, so this
+   is a good approximation there. It says nothing about variadic arities,
+   which are compiled to `doInvoke` instead."
+  [f]
   (->> (class f)
        .getDeclaredMethods
        (filter (fn [^Method m] (= "invoke" (.getName m))))
        (map #(alength (.getParameterTypes ^Method %)))
        (set)))
 
+(defn- arities
+  "Set of arities `f` accepts.
+
+   `:arglists` metadata is preferred when present: it is the portable way to
+   describe a fn's signatures, and unlike class reflection it is also correct
+   on runtimes that represent every fn with a single shared class.
+
+   Variadic signatures contribute only their required arity, so prefer
+   `accepts-arity?` over testing this set directly."
+  [f]
+  (if-let [arglists (:arglists (meta f))]
+    (into #{} (map required-arity) arglists)
+    (cond-> (declared-invoke-arities f)
+      (instance? RestFn f) (conj (.getRequiredArity ^RestFn f)))))
+
+(defn- accepts-arity?
+  "Whether `f` can be called with `n` arguments. Unlike `arities`, this
+   accounts for variadic signatures, which accept their required arity or more."
+  [f n]
+  (if-let [arglists (:arglists (meta f))]
+    (boolean (some (fn [arglist]
+                     (let [required (required-arity arglist)]
+                       (if (variadic-arglist? arglist)
+                         (<= required n)
+                         (= required n))))
+                   arglists))
+    (or (contains? (declared-invoke-arities f) n)
+        (and (instance? RestFn f)
+             (<= (.getRequiredArity ^RestFn f) n)))))
+
 (defn- error-without-arity-2? [{error-fn :error}]
-  (and error-fn (not (contains? (arities error-fn) 2))))
+  (and error-fn (not (accepts-arity? error-fn 2))))
 
 (defn- error-arity-2->1 [error]
   (fn [context ex]

--- a/test/clj/reitit/pedestal_test.clj
+++ b/test/clj/reitit/pedestal_test.clj
@@ -9,7 +9,28 @@
 (deftest arities-test
   (is (= #{0} (#'pedestal/arities (fn []))))
   (is (= #{1} (#'pedestal/arities (fn [_]))))
-  (is (= #{0 1 2} (#'pedestal/arities (fn ([]) ([_]) ([_ _]))))))
+  (is (= #{0 1 2} (#'pedestal/arities (fn ([]) ([_]) ([_ _])))))
+  (testing "variadic fns report their required arity"
+    (is (= #{0} (#'pedestal/arities (fn [& _]))))
+    (is (= #{1} (#'pedestal/arities (fn [_ & _]))))
+    (is (= #{1 2} (#'pedestal/arities (fn ([_]) ([_ _ & _]))))))
+  (testing ":arglists metadata is preferred over reflection"
+    (is (= #{2} (#'pedestal/arities (with-meta (fn [& _]) {:arglists '([_ _])}))))
+    (is (= #{0 1} (#'pedestal/arities (with-meta (fn [& _]) {:arglists '([] [_])}))))))
+
+(deftest accepts-arity?-test
+  (testing "fixed arities"
+    (is (#'pedestal/accepts-arity? (fn [_ _]) 2))
+    (is (not (#'pedestal/accepts-arity? (fn [_]) 2)))
+    (is (not (#'pedestal/accepts-arity? (fn [_ _ _]) 2))))
+  (testing "variadic arities accept their required arity or more"
+    (is (#'pedestal/accepts-arity? (fn [& _]) 2))
+    (is (#'pedestal/accepts-arity? (fn [_ & _]) 2))
+    (is (not (#'pedestal/accepts-arity? (fn [_ _ _ & _]) 2))))
+  (testing ":arglists metadata is preferred over reflection"
+    (is (#'pedestal/accepts-arity? (with-meta (fn [& _]) {:arglists '([_ _])}) 2))
+    (is (#'pedestal/accepts-arity? (with-meta (fn [& _]) {:arglists '([_ & _])}) 2))
+    (is (not (#'pedestal/accepts-arity? (with-meta (fn [& _]) {:arglists '([_])}) 2)))))
 
 (deftest interceptor-test
   (testing "without :enter, :leave or :error are stripped"


### PR DESCRIPTION
## Summary

Variadic arities are compiled to `doInvoke`, not `invoke`, so they are
invisible here:

| `f` | `arities` before | actual |
| --- | --- | --- |
| `(fn [& _])` | `#{}` | 0 or more |
| `(fn [_ & _])` | `#{}` | 1 or more |
| `(fn ([_]) ([_ _ & _]))` | `#{1}` | 1, or 2 or more |

The one caller is `error-without-arity-2?`, so a variadic `:error`
handler is misread as not supporting 2-arity and gets wrapped by
`error-arity-2->1`. A handler written as `(fn [context ex] ...)` via
`& args`, or one returned by a combinator such as `partial`/`comp`,
is silently called with the Sieppari 1-arity convention instead of
Pedestal's 2-arity one.

## Change

`arities` now prefers `:arglists` metadata when present, and otherwise
combines the declared `invoke` methods with `RestFn.getRequiredArity`,
which covers both purely variadic and mixed fixed/variadic fns.

`:arglists` is checked first because it is the portable description of a
fn's signatures. Class reflection encodes an assumption specific to the
JVM compiler — one class per fn, declaring only the arities it defines.
That does not hold on alternative Clojure runtimes which represent every
fn with one shared class implementing all `invoke` overloads; there,
`arities` returns `#{0..21}` and every `:error` handler looks like it
accepts any arity. Honouring `:arglists` gives such runtimes (and anyone
using `with-meta`) a portable way to report real arities, at no cost on
the JVM where anonymous fns have no metadata and the reflection path
is unchanged.

The single call site now uses a small `accepts-arity?` helper instead of
`contains?` on a set, because a set of arities cannot express "n
arguments or more" without inventing an upper bound.

Apologies for the LLM summary!

## Motivation

The original motivation is that we are working on a GraalVM fork of Clojure at https://github.com/The-Alchemist/cloffle-clojure which does not generate JVM bytecode so `.getDeclaredFields` doesn't exist.  Adding variadic support does two things at once.

## Compatibility

No public API change; `arities` is private. Behaviour for non-variadic
fns is unchanged, including the existing `arities-test` assertions.
Variadic `:error` handlers that accept 2 args are no longer wrapped —
that is the bug fix, and it only affects handlers that were being
called with the wrong convention before.


Opened as a draft — happy to add a CHANGELOG entry or adjust the shape
of the helpers if you would prefer to keep this to a single fn.
