### PR TITLE
Extend reitit.walk keywordize to IPersistentVector

### DIFF
--- a/modules/reitit-core/src/reitit/walk.clj
+++ b/modules/reitit-core/src/reitit/walk.clj
@@ -19,8 +19,10 @@
   [coll]
   (into (empty coll) keywordize-xf coll))
 
+;; Protocol extend is exact-class. IPersistentVector covers PersistentVector,
+;; subvec (APersistentVector$SubVector), and other IPersistentVector impls.
 (doseq [type [clojure.lang.PersistentHashSet
-              clojure.lang.PersistentVector
+              clojure.lang.IPersistentVector
               clojure.lang.PersistentQueue
               clojure.lang.PersistentStructMap
               clojure.lang.PersistentTreeSet]]

--- a/test/clj/reitit/walk_test.clj
+++ b/test/clj/reitit/walk_test.clj
@@ -1,10 +1,15 @@
 (ns reitit.walk-test
   (:require
+   [clojure.test :refer [deftest is]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.properties :as prop]
    [clojure.test.check.generators :as gen]
    [clojure.walk :as walk]
    [reitit.walk :as sut]))
+
+(deftest keywordize-subvec
+  (is (= (sut/keywordize-keys (subvec [{"a" 1} {"b" 2}] 0 2))
+         (walk/keywordize-keys (subvec [{"a" 1} {"b" 2}] 0 2)))))
 
 (defspec keywordize=walk-keywordize
   10000


### PR DESCRIPTION
## Summary
- `reitit.walk` extends `IKeywordize` to `PersistentVector` by exact class. `subvec` (`APersistentVector$SubVector`) and other `IPersistentVector` implementations therefore fall through to `Object` and are not walked, so `keywordize-keys` disagrees with `clojure.walk`.
- Extend `clojure.lang.IPersistentVector` instead, matching the existing `IPersistentMap` fallback. `PersistentVector` behavior is unchanged.
- Add a `keywordize-subvec` regression test (`gen/any-equatable` never produces subvecs).

## Motivation
[Cloffle](https://github.com/The-Alchemist/cloffle-clojure) is a Truffle/GraalVM implementation of Clojure. Its small vectors are `PersistentTuple` (`IPersistentVector`, not `PersistentVector`), so `reitit.walk/keywordize-keys` skipped nested maps inside `(vector …)` while `clojure.walk` did not. The same exact-class gap shows up on JVM Clojure with `subvec`. Extending `IPersistentVector` covers both.