### PR TITLE
Fix SFLJ4 warning: Exclude legacy logback-classic from immutant-web

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -110,7 +110,7 @@
                                   [orchestra "2021.01.01-1"]
 
                                   [ring "1.15.5"]
-                                  [ikitommi/immutant-web "3.0.0-alpha1"]
+                                  [ikitommi/immutant-web "3.0.0-alpha1" :exclusions [ch.qos.logback/logback-classic]]
                                   [metosin/ring-http-response "0.9.5"]
                                   [metosin/ring-swagger-ui "5.32.11"]
                                   [org.clojure/tools.analyzer "1.2.2"]
@@ -139,7 +139,7 @@
                     :test-paths ["perf-test/clj"]
                     :dependencies [[compojure "1.7.2"]
                                    [ring/ring-defaults "0.7.1"]
-                                   [ikitommi/immutant-web "3.0.0-alpha1"]
+                                   [ikitommi/immutant-web "3.0.0-alpha1" :exclusions [ch.qos.logback/logback-classic]]
                                    [io.pedestal/pedestal.service "0.6.4" :upgrade false]
                                    [io.pedestal/pedestal.jetty "0.6.4" :upgrade false]
                                    [calfpath "0.8.1"]


### PR DESCRIPTION
### Description

`ikitommi/immutant-web:3.0.0-alpha1` (via `org.projectodd.wunderboss/wunderboss-core:0.13.1`) pulls in `ch.qos.logback/logback-classic:1.1.3`.

Because `ring:1.15.5` pulls in Jetty 12 and `org.slf4j/slf4j-api:2.0.17`, running tests or dev tooling produces SLF4J 2.x warnings about ignored legacy bindings targeting SLF4J 1.7.x or earlier:

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [jar:file:.../ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```


## Question

`immutant` is so old, maybe we should remove that part of the code as a whole?